### PR TITLE
allows CV param override

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -34,9 +34,12 @@ class Storyblok {
       if (!query.version) {
         query.version = 'published'
       }
-
+      
+      if (!query.cv) {
+        query.cv = this.cacheVersion
+      }
+      
       query.token = this.getToken()
-      query.cv = this.cacheVersion
     }
 
     return this.cacheResponse(url, query)


### PR DESCRIPTION
if `query.cv` is provided do not use own caching strategy.