### PR TITLE
Remove unused object-hash dependency

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7,7 +7,6 @@ var _createClass = function () { function defineProperties(target, props) { for 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var API_ENDPOINT_DEFAULT = 'https://api.storyblok.com/v1';
-var hash = require('object-hash');
 var qs = require('qs');
 var axios = require('axios');
 var throttledQueue = require('throttled-queue');

--- a/source/index.js
+++ b/source/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const API_ENDPOINT_DEFAULT = 'https://api.storyblok.com/v1'
-const hash = require('object-hash')
 const qs = require('qs')
 const axios = require('axios')
 const throttledQueue = require('throttled-queue')


### PR DESCRIPTION
The object-hash package was not used anymore but it was still required
in the source file. This lead to webpack failing with the following
message:

> This dependency was not found:
>
> * object-hash in ./node_modules/storyblok-js-client/dist/index.js