### PR TITLE
BUGFIX: Stories should allow more than one story

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -47,7 +47,7 @@ export interface StoryblokResult {
   headers: any
 }
 
-export interface StoryContent {
+export interface StoryData {
   alternates: string[]
   content: {
     component: string
@@ -72,7 +72,7 @@ export interface StoryContent {
 
 export interface Stories {
   data: {
-    stories: StoryContent[]
+    stories: StoryData[]
   }
   perPage: number
   total: number
@@ -81,7 +81,7 @@ export interface Stories {
 
 export interface Story {
   data: {
-    story: StoryContent
+    story: StoryData
   }
   headers: any
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,6 +1,6 @@
 declare global {
   interface StoryblokBridgeConfig {
-    initOnlyOnce?: boolean,
+    initOnlyOnce?: boolean
     accessToken?: string
   }
   interface StoryblokEventPayload {
@@ -15,7 +15,10 @@ declare global {
     pingEditor: () => void
     isInEditor: () => void
     enterEditmode: () => void
-    on: (event: 'customEvent' | 'published' | 'input' | 'change' | 'unpublished' | 'enterEditmode' | string[], callback: (payload?: StoryblokEventPayload) => void) => void
+    on: (
+      event: 'customEvent' | 'published' | 'input' | 'change' | 'unpublished' | 'enterEditmode' | string[],
+      callback: (payload?: StoryblokEventPayload) => void,
+    ) => void
   }
   interface Window {
     storyblok: StoryblokBridge
@@ -44,30 +47,32 @@ export interface StoryblokResult {
   headers: any
 }
 
+export interface StoryContent {
+  alternates: string[]
+  content: {
+    component: string
+    _uid: string
+    [index: string]: any
+  }
+  created_at: string
+  full_slug: string
+  group_id: string
+  id: number
+  is_startpage: boolean
+  meta_data: any
+  name: string
+  parent_id: number
+  position: number
+  published_at: string | null
+  slug: string
+  sort_by_date: string | null
+  tag_list: string[]
+  uuid: string
+}
+
 export interface Stories {
   data: {
-    stories: {
-      alternates: string[]
-      content: {
-        component: string
-        _uid: string
-        [index: string]: any
-      }
-      created_at: string
-      full_slug: string
-      group_id: string
-      id: number
-      is_startpage: boolean
-      meta_data: any
-      name: string
-      parent_id: number
-      position: number
-      published_at: string | null
-      slug: string
-      sort_by_date: string | null
-      tag_list: string[]
-      uuid: string
-    }
+    stories: StoryContent[]
   }
   perPage: number
   total: number
@@ -76,28 +81,7 @@ export interface Stories {
 
 export interface Story {
   data: {
-    story: {
-      alternates: string[]
-      content: {
-        component: string
-        _uid: string
-        [index: string]: any
-      }
-      created_at: string
-      full_slug: string
-      group_id: string
-      id: number
-      is_startpage: boolean
-      meta_data: any
-      name: string
-      parent_id: number
-      position: number
-      published_at: string | null
-      slug: string
-      sort_by_date: string | null
-      tag_list: string[]
-      uuid: string
-    }
+    story: StoryContent
   }
   headers: any
 }


### PR DESCRIPTION
The important thing that this PR should fix is that `Stories.data.stories` expected a single object rather than an array of objects. I have abstracted that object out into `StoryData` and allowed `Stories` to have an array of those:

```typescript
export interface StoryData {
  alternates: string[]
  content: {
    component: string
    _uid: string
    [index: string]: any
  }
  created_at: string
  full_slug: string
  group_id: string
  id: number
  is_startpage: boolean
  meta_data: any
  name: string
  parent_id: number
  position: number
  published_at: string | null
  slug: string
  sort_by_date: string | null
  tag_list: string[]
  uuid: string
}

export interface Stories {
  data: {
    stories: StoryData[]
  }
  perPage: number
  total: number
  headers: any
}

export interface Story {
  data: {
    story: StoryData
  }
  headers: any
}
```

Does this make sense?