### PR TITLE
upgraded axios to 0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "randomatic": ">=3.0.0"
   },
   "dependencies": {
-    "axios": "^0.17.1",
+    "axios": "^0.18.0",
     "qs": "^6.5.2",
     "throttle-promise": "^1.0.4"
   }


### PR DESCRIPTION
Storyblok-js client depends on axios version ^0.17.1. Current version shipped with nuxt is 0.18. 
I do have both axios 0.17.1 and 0.18 bundled by webpack. To avoid this duplicate content, it would be great to update package.json to now have 0.18.

I've made the very small change in the package.json. My npm install will change the package-lock.json so I didn't commit it. There are some vulnerabilities listed from npm install.