### PR TITLE
Add ability to specify Content type for StoryData

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -56,12 +56,11 @@ export interface StoryblokManagmentApiResult {
   headers: any
 }
 
-export interface StoryData {
+export interface StoryData<Content = { [index: string]: any }> {
   alternates: string[]
-  content: {
+  content: Content & {
     component: string
     _uid: string
-    [index: string]: any
   }
   created_at: string
   full_slug: string


### PR DESCRIPTION
This change gives you the ability to pass a type for content in order to strongly type the `content` property

Example: 
```
interface MyContent {
   heading: string
   date: string
}

const story: StoryData<MyContent> = { ... }  
// This works
story.content.heading
// This will error
story.content.foobar
```
This wont affect the any current usages of the type
```
const story: StoryData = { ... }  
story.content.anythingYouWant
```