### PR TITLE
Feat/Async Cache provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Storyblok
 
 **Parameters**
 
-- `[return]` Object, returns the Storyblok client
+- `[return]` Promise, Object returns the Storyblok client
 
 **Example**
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -149,7 +149,7 @@ declare class Storyblok {
   cacheResponse(url: string, params: any): Promise<StoryblokResult>
   newVersion(): number
   cacheProvider(): StoryblokCacheProvider
-  flushCache(): this
+  flushCache(): Promise<this>
 }
 
 export default Storyblok

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -27,7 +27,7 @@ declare global {
   }
 }
 
-import { AxiosInstance } from 'axios'
+import { AxiosInstance, AxiosProxyConfig } from 'axios'
 
 export interface StoryblokConfig {
   accessToken?: string

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -18,7 +18,7 @@ declare global {
     enterEditmode: () => void
     on: (
       event: 'customEvent' | 'published' | 'input' | 'change' | 'unpublished' | 'enterEditmode' | string[],
-      callback: (payload?: StoryblokEventPayload) => void,
+      callback: (payload?: StoryblokEventPayload) => void
     ) => void
   }
   interface Window {
@@ -37,11 +37,20 @@ export interface StoryblokConfig {
   headers?: any
   region?: string
   maxRetries?: number
+  https?: boolean
+  rateLimit?: number
+  proxy?: AxiosProxyConfig
 }
 
 export interface StoryblokCache {
   type?: 'memory'
   clear?: 'auto' | 'manual'
+}
+
+export interface StoryblokCacheProvider {
+  get: (key: string) => Promise<StoryblokResult> | StoryblokResult
+  set: (key: string, content: StoryblokResult) => Promise<void> | any
+  flush: () => Promise<void> | void
 }
 
 export interface StoryblokResult {
@@ -139,11 +148,7 @@ declare class Storyblok {
   getToken(): string
   cacheResponse(url: string, params: any): Promise<StoryblokResult>
   newVersion(): number
-  cacheProvider(): {
-    get(key: string): any
-    set(key: string, content: string): void
-    flush(): void
-  }
+  cacheProvider(): StoryblokCacheProvider
   flushCache(): this
 }
 

--- a/source/index.js
+++ b/source/index.js
@@ -7,6 +7,7 @@ const delay = ms => new Promise(res => setTimeout(res, ms))
 let memory = {}
 
 class Storyblok {
+
   constructor(config, endpoint) {
     if (!endpoint) {
       let region = config.region ? `-${config.region}` : ''
@@ -28,14 +29,14 @@ class Storyblok {
 
     this.maxRetries = config.maxRetries || 5
     this.throttle = throttledQueue(this.throttledRequest, rateLimit, 1000)
-    this.cacheVersion = this.cacheVersion || this.newVersion()
+    this.cacheVersion = (this.cacheVersion || this.newVersion())
     this.accessToken = config.accessToken
-    this.cache = config.cache || { clear: 'manual' }
+    this.cache = (config.cache || { clear: 'manual' })
     this.client = axios.create({
       baseURL: endpoint,
-      timeout: config.timeout || 0,
+      timeout: (config.timeout || 0),
       headers: headers,
-      proxy: config.proxy || false
+      proxy: (config.proxy || false)
     })
   }
 


### PR DESCRIPTION
Currently it's not possible to use a cache provider that has async methods. This change allows you to do just that. Still works with built in `memory` provider

- Enable ability for CacheProvider to be `async`
- Restructured the call to the cache in `cachedResponse` if `params.version` isn't `published` as the response wasn't used.
- Added missing properties on `StoryblokConfig` interface

### Override Usage
```
class Client extends Storyblok { 
    cacheProvider() {
       return {
          get: async (key) =>  .... ,
          set: async (key, content) =>  .... ,
          flush: async () => ...
        }
     }
}
```