### PR TITLE
Fix signature of getAll

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -148,7 +148,7 @@ declare class Storyblok {
   richTextResolver: RichtextInstance
   constructor(config: StoryblokConfig, endpoint?: string)
   get(slug: string, params?: any): Promise<StoryblokResult>
-  getAll(slug: string, params?: any, entity: string): Promise<Array>
+  getAll(slug: string, params?: any, entity?: string): Promise<any[]>
   post(slug: string, params?: any): Promise<StoryblokManagmentApiResult>
   put(slug: string, params?: any): Promise<StoryblokManagmentApiResult>
   delete(slug: string, params?: any): Promise<StoryblokManagmentApiResult>


### PR DESCRIPTION
The current version creates 2 issues (at least in TS strict mode, version 3.5.3):

<img width="987" alt="image" src="https://user-images.githubusercontent.com/143797/67262512-5be49900-f4a5-11e9-9984-2bf6ab392d30.png">
