### PR TITLE
update StoriesParams with by_uuids_ordered

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -113,6 +113,7 @@ export interface StoriesParams {
   is_startpage?: 0 | 1
   starts_with?: string
   by_uuids?: string
+  by_uuids_ordered?: string
   excluding_ids?: string
   excluding_fields?: string
   resolve_links?: 'url' | 'story' | '0' | '1'


### PR DESCRIPTION
Currently `by_uuids_ordered` is  missing in the StoriesParams type. https://www.storyblok.com/docs/api/content-delivery#core-resources/stories/retrieve-multiple-stories