### PR TITLE
missing type definitions and prepare npm script

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -125,6 +125,11 @@ export interface StoriesParams {
   per_page?: number
   page?: string
   from_release?: string
+  fallback_language?: string
+  first_published_at_gt?: string
+  first_published_at_lt?: string
+  published_at_gt?: string
+  published_at_lt?: string
 }
 
 export interface StoryParams {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -20,6 +20,7 @@ declare global {
       event: 'customEvent' | 'published' | 'input' | 'change' | 'unpublished' | 'enterEditmode' | string[],
       callback: (payload?: StoryblokEventPayload) => void
     ) => void
+    addComments: (tree: StoryblokComponent<string>, storyId: string) => StoryblokComponent<string>
   }
   interface Window {
     storyblok: StoryblokBridge

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "babel source --out-dir dist",
+    "prepare": "npm run-script build",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
This PR fixes:
* missing some type definitions in `StoriesParams` interface
* missing type definition of addComments function (reported by #41)
* missing `prepare` npm script to build the package before publish it