### PR TITLE
type definition to richtext render method

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Storyblok.setComponentResolver((component, blok) => {
 
 **Parameters**
 - `[return]` String, Rendered html of a richtext field
-- `richtext` Object, Json object from a richtext field
+- `data` Richtext object, An object with a `content` (an array of nodes) field.
 
 **Example**
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -144,8 +144,12 @@ export interface StoryParams {
   from_release?: string
 }
 
+export interface Richtext {
+  content: Array<Object>
+}
+
 export interface RichtextInstance {
-  render: (richtext: any) => string
+  render: (data: Richtext) => string
 }
 
 declare class Storyblok {

--- a/source/richTextResolver.js
+++ b/source/richTextResolver.js
@@ -35,14 +35,19 @@ class RichTextResolver {
     this.marks[key] = schema
   }
 
-  render(data) {
-    let html = ''
+  render(data = {}) {
+    if (data.content && Array.isArray(data.content)) {
+      let html = ''
 
-    data.content.forEach((node) => {
-      html += this.renderNode(node)
-    })
+      data.content.forEach((node) => {
+        html += this.renderNode(node)
+      })
 
-    return html
+      return html
+    }
+
+    console.warn('The render method must receive an object with a content field, which is an array')
+    return ''
   }
 
   renderNode(item) {

--- a/tests/richTextResolver.test.js
+++ b/tests/richTextResolver.test.js
@@ -2,6 +2,19 @@ const RichTextResolver = require('../source/richTextResolver')
 
 let resolver = new RichTextResolver()
 
+test('call render function without any argument return an empty string', () => {
+  expect(resolver.render()).toBe('')
+})
+
+test('call render function with a incorrect object return an empty string', () => {
+  expect(resolver.render({})).toBe('')
+  expect(resolver.render({ test: [] })).toBe('')
+})
+
+test('call render function with an object.content equals an empty return an empty string', () => {
+  expect(resolver.render({ content: [] })).toBe('')
+})
+
 test('styled mark to add span with red class', () => {
   const doc = {
     type: 'doc',


### PR DESCRIPTION
Update the type definition and documentation about the `render` method in `RichtextInstance`.