### PR TITLE
Fix type of alternates property in `StoryData`

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -74,7 +74,7 @@ export interface StoryblokComponent<TComp extends string> {
 }
 
 export interface StoryData<Content = StoryblokComponent<string> & { [index: string]: any }> {
-  alternates: string[]
+  alternates: AlternateLink[]
   content: Content 
   created_at: string
   full_slug: string
@@ -90,6 +90,16 @@ export interface StoryData<Content = StoryblokComponent<string> & { [index: stri
   sort_by_date: string | null
   tag_list: string[]
   uuid: string
+}
+
+interface AlternateObject {
+  id: number;
+  name: string;
+  slug: string;
+  published: boolean;
+  full_slug: string;
+  is_folder: boolean;
+  parent_id: number;
 }
 
 export interface Stories {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -92,7 +92,7 @@ export interface StoryData<Content = StoryblokComponent<string> & { [index: stri
   uuid: string
 }
 
-interface AlternateObject {
+export interface AlternateObject {
   id: number;
   name: string;
   slug: string;


### PR DESCRIPTION
According to the docs, the `alternates` property of a story is an object, not a string.

Source: https://www.storyblok.com/docs/api/content-delivery#core-resources/stories/the-story-object