### PR TITLE
richtext prevent content mutation

### DIFF
--- a/source/richTextResolver.js
+++ b/source/richTextResolver.js
@@ -66,7 +66,7 @@ class RichTextResolver {
     const node = this.getMatchingNode(item)
 
     if (node && node.tag) {
-      html.push(this.renderOpeningTag(node.tag)) 
+      html.push(this.renderOpeningTag(node.tag))
     }
 
     if (item.content) {
@@ -82,11 +82,11 @@ class RichTextResolver {
     }
 
     if (node && node.tag) {
-      html.push(this.renderClosingTag(node.tag)) 
+      html.push(this.renderClosingTag(node.tag))
     }
 
     if (item.marks) {
-      item.marks.reverse().forEach((m) => {
+      item.marks.slice(0).reverse().forEach((m) => {
         const mark = this.getMatchingMark(m)
 
         if (mark) {
@@ -132,7 +132,7 @@ class RichTextResolver {
       return `</${tags}>`
     }
 
-    const all = tags.reverse().map((tag) => {
+    const all = tags.slice(0).reverse().map((tag) => {
       if (tag.constructor === String) {
         return `</${tag}>`
       } else {

--- a/tests/richTextResolver.test.js
+++ b/tests/richTextResolver.test.js
@@ -149,3 +149,29 @@ test('code_block to generate a pre and code tag', () => {
 
   expect(resolver.render(doc)).toBe('<pre><code>code</code></pre>')
 })
+
+test('escape html marks from text', () => {
+  const doc = {
+    type: 'doc',
+    content: [{
+        type: 'paragraph',
+        content: [{
+          text: '<p>Footer data</p>',
+          type: 'text'
+        }]
+      },
+      {
+        type: 'paragraph',
+        content: [{
+          text: 'Another footer data',
+          type: 'text',
+          marks: [{
+            type: 'bold'
+          }]
+        }]
+      }
+    ]
+  }
+
+  expect(resolver.render(doc)).toBe('<p>&ltp&gtFooter data&lt/p&gt</p><p><b>Another footer data</b></p>')
+})


### PR DESCRIPTION
[Relates to Storyblok Nuxt issue](https://github.com/storyblok/storyblok-nuxt/issues/8).

Use of `Array.slice` method before `Array.reverse` method to prevent Array mutation. This behavior can be a problem when the `Richtext.render` method receives as an argument a data that cannot change (like from Vuex, for example). And this PR makes the render method more "functional".