### PR TITLE
fix: Move runtime-corejs3 to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "@babel/core": "^7.4.0",
     "@babel/plugin-transform-runtime": "^7.4.0",
     "@babel/preset-env": "^7.4.2",
+    "@babel/runtime-corejs3": "^7.4.5",
     "jest": "^25.1.0"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.4.5",
     "axios": "^0.19.0",
     "qs": "^6.5.2"
   }


### PR DESCRIPTION
Not totally sure if this package is needed on lib land. Usually polyfills are left up to the user land, because they add extra size to the package bundle.

In this case, it adds a bunch of core-js modules (**~40KB** parsed), making those dependencies **4x times bigger** than storyblok-js client itself (~10KB parsed)

![image](https://user-images.githubusercontent.com/5701162/82440787-32243c80-9a9d-11ea-9a6c-f34c27aa5ecf.png)

I guess moving it to devDependencies should solve this because @babel/runtime-corejs3 should do its stuff on build time, transforming and adding polyfills where needed. But adding it as a dependency will end up in the whole package being installed in user's app. 

Otherwise, can we just add the necessary polyfills instead? IMHO, this is a no-go when I'm looking performance-wise to add a lib to my project.

Thanks!