### PR TITLE
fix: make sure fieldtype exists on node

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -170,7 +170,7 @@ class Storyblok {
   _insertLinks(jtree, treeItem) {
     const node = jtree[treeItem]
 
-    if (node.fieldtype == 'multilink' &&
+    if (node && node.fieldtype == 'multilink' &&
         node.linktype == 'story' &&
         typeof node.id === 'string' &&
         this.links[node.id]) {


### PR DESCRIPTION
I have this error in my console on some rare occasions, make sure that node exists