### PR TITLE
fix(client): use v1 for management API based on oauthToken

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -17,18 +17,22 @@ class Storyblok {
     if (!endpoint) {
       let region = config.region ? `-${config.region}` : ''
       let protocol = config.https === false ? 'http' : 'https'
-      endpoint = `${protocol}://api${region}.storyblok.com/v2`
+      if (typeof config.oauthToken === 'undefined') {
+        endpoint = `${protocol}://api${region}.storyblok.com/v2`
+      } else {
+        endpoint = `${protocol}://mpi${region}.storyblok.com/v1`
+      }
     }
 
     let headers = Object.assign({}, config.headers)
     let rateLimit = 5 // per second for cdn api
 
-    if (typeof config.oauthToken != 'undefined') {
+    if (typeof config.oauthToken !== 'undefined') {
       headers['Authorization'] = config.oauthToken
       rateLimit = 3 // per second for management api
     }
 
-    if (typeof config.rateLimit != 'undefined') {
+    if (typeof config.rateLimit !== 'undefined') {
       rateLimit = config.rateLimit
     }
 

--- a/source/index.js
+++ b/source/index.js
@@ -20,7 +20,7 @@ class Storyblok {
       if (typeof config.oauthToken === 'undefined') {
         endpoint = `${protocol}://api${region}.storyblok.com/v2`
       } else {
-        endpoint = `${protocol}://mpi${region}.storyblok.com/v1`
+        endpoint = `${protocol}://api${region}.storyblok.com/v1`
       }
     }
 

--- a/source/index.js
+++ b/source/index.js
@@ -25,7 +25,7 @@ class Storyblok {
     }
 
     let headers = Object.assign({}, config.headers)
-    let rateLimit = 5 // per second for cdn api
+    let rateLimit = 5 // per second for cdn api 
 
     if (typeof config.oauthToken !== 'undefined') {
       headers['Authorization'] = config.oauthToken


### PR DESCRIPTION
Use management API version v1 if oauthToken is not set. Only set v2 of content delivery if `oauthToken` is not set. 
Currently Users will receive a 404 when using the JS client for management options.

## Immediate Workaround:

Initialize the JS client with:

```
endpoint: "https://api.storyblok.com/v1"
```