### PR TITLE
feat: story objects in links and relations inside the rich text editor

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -179,6 +179,9 @@ class Storyblok {
         typeof node.id === 'string' &&
         this.links[node.id]) {
       node.story = this._cleanCopy(this.links[node.id])
+    } else if(node && node.linktype === 'story' &&
+      typeof node.uuid === 'string' && this.links[node.uuid]) {
+      node.story = this._cleanCopy(this.links[node.uuid])
     }
   }
 
@@ -209,11 +212,12 @@ class Storyblok {
         for (let item = 0; item < jtree.length; item++) {
           enrich(jtree[item])
         }
-      } else if (jtree.constructor === Object && jtree.component && jtree._uid) {
+      } else if (jtree.constructor === Object) {
         for (let treeItem in jtree) {
-          this._insertRelations(jtree, treeItem, fields)
-          this._insertLinks(jtree, treeItem)
-
+          if((jtree.component && jtree._uid) || jtree.type === 'link') {
+            this._insertRelations(jtree, treeItem, fields)
+            this._insertLinks(jtree, treeItem)
+          }
           enrich(jtree[treeItem])
         }
       }


### PR DESCRIPTION
This PR resolves #103 : it makes links and relations inside components and links in a Rich Text Editor field get the data from their linked stories. [These lines](https://github.com/storyblok/storyblok-js-client/blob/4a6ab2cd30089c6d863f3c610f1b75be5cdf2674/source/index.js#L182-L185) will inject the object also inside inline links. 