### PR TITLE
feat: limit the depth of resolved objects nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ import StoryblokClient from 'storyblok-js-client/dist/es5/index.es'
   - (`timeout` Integer, optional)
   - (`maxRetries` Integer, optional, defaults to 5)
   - (`richTextSchema` Object, optional - your custom schema for RichTextRenderer)
-  - (`maxResolveDepth` Integer, optional, defaults to 3 - you can set a limit to the nesting of resolved objects in links or relations)
+  - (`maxResolveDepth` Integer, optional, defaults to 6 - you can set a limit to the nesting of resolved objects in links or relations)
 - (`endpoint` String, optional)
 
 ### Activating request cache

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ import StoryblokClient from 'storyblok-js-client/dist/es5/index.es'
   - (`timeout` Integer, optional)
   - (`maxRetries` Integer, optional, defaults to 5)
   - (`richTextSchema` Object, optional - your custom schema for RichTextRenderer)
+  - (`maxResolveDepth` Integer, optional, defaults to 3 - you can set a limit to the nesting of resolved objects in links or relations)
 - (`endpoint` String, optional)
 
 ### Activating request cache

--- a/source/index.js
+++ b/source/index.js
@@ -206,7 +206,6 @@ class Storyblok {
 
   iterateTree(story, fields) {
     let enrich = (jtree, depth) => {
-      console.log(depth)
       if (jtree == null) {
         return
       }

--- a/source/index.js
+++ b/source/index.js
@@ -48,7 +48,7 @@ class Storyblok {
     this.relations = {}
     this.links = {}
     this.cache = (config.cache || { clear: 'manual' })
-    this.maxResolveDepth = config.maxResolveDepth || 3
+    this.maxResolveDepth = config.maxResolveDepth || 6
     this.client = axios.create({
       baseURL: endpoint,
       timeout: (config.timeout || 0),


### PR DESCRIPTION
This PR sets a limit to the depth of nesting resolved objects with `resolve_links` and `resolve_relations`. This feature resolves issues that can occur when there's a circular reference between 2 entries, which will cause an infinite loop. 
I have introduced a configuration parameter called `maxResolveDepth` which defaults to 6 and allows users to set their own limit.