### PR TITLE
fix(types): add `level` to StoriesParams

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -151,6 +151,7 @@ export interface StoriesParams {
   fallback_lang?: string
   first_published_at_gt?: string
   first_published_at_lt?: string
+  level?: number
   published_at_gt?: string
   published_at_lt?: string
   by_slugs?: string


### PR DESCRIPTION
Add the missing `level` parameter to the types for retrieving multiple stories