### PR TITLE
fix: Remove default language fallback in resolved relations

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -272,7 +272,7 @@ class Storyblok {
       }
 
       for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
-        let relationsRes = await this.getStories({per_page: chunkSize, language: params.language || 'default', version: params.version, by_uuids: chunks[chunkIndex].join(',')})
+        let relationsRes = await this.getStories({per_page: chunkSize, language: params.language, version: params.version, by_uuids: chunks[chunkIndex].join(',')})
 
         relationsRes.data.stories.forEach((rel) => {
           relations.push(rel)


### PR DESCRIPTION
This PR addresses a breaking change introduced in #122. It removes the `"default"` fall through for the language parameter when resolving relations. It still allows any manually set language parameter to pass through to relation requests.

fixes #133 