### PR TITLE
fix: send the language parameter to links resolver

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -243,7 +243,7 @@ class Storyblok {
       }
 
       for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
-        let linksRes = await this.getStories({per_page: chunkSize, version: params.version, by_uuids: chunks[chunkIndex].join(',')})
+        let linksRes = await this.getStories({per_page: chunkSize, language: params.language, version: params.version, by_uuids: chunks[chunkIndex].join(',')})
 
         linksRes.data.stories.forEach((rel) => {
           links.push(rel)
@@ -272,7 +272,7 @@ class Storyblok {
       }
 
       for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
-        let relationsRes = await this.getStories({per_page: chunkSize, language: params.language || 'default', version: params.version, by_uuids: chunks[chunkIndex].join(',')})
+        let relationsRes = await this.getStories({per_page: chunkSize, language: params.language, version: params.version, by_uuids: chunks[chunkIndex].join(',')})
 
         relationsRes.data.stories.forEach((rel) => {
           relations.push(rel)


### PR DESCRIPTION
This PR fixes an issue with the links resolver method which is not passing the lang parameter along with the other parameters, so the resolved links are not in the same language as the retrieved stories. 
I've also removed the `default` fallback to the relations resolver as it would include also this bug #134 which is about languages too.