### PR TITLE
refactor(int-247): JS: add exports fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
       "require": "./dist/index.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -15,12 +15,8 @@
     "types",
     "test"
   ],
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.mjs"
-    }
-  },
+  "exports": "./dist/index.js",
+
   "scripts": {
     "clean": "rimraf dist/",
     "build": "run-s clean build:**",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "require": "./dist/index.mjs"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
     "types",
     "test"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "scripts": {
     "clean": "rimraf dist/",
     "build": "run-s clean build:**",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,12 @@
     "types",
     "test"
   ],
-  "exports": "./dist/index.js",
-
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "scripts": {
     "clean": "rimraf dist/",
     "build": "run-s clean build:**",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -59,7 +59,7 @@ const plugins = [
   mjsEntry(),
 
   // to resolve correctly non-esmodules packages
-  rollupResolve({ jsnext: true, preferBuiltins: true, browser: true, modulesOnly: true }),
+  rollupResolve({ jsnext: true, preferBuiltins: true, browser: true}),
 
   // to include, when not external, non-esmodules packages (axios and qs e.g)
   rollupCommonjs(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -59,7 +59,7 @@ const plugins = [
   mjsEntry(),
 
   // to resolve correctly non-esmodules packages
-  rollupResolve({ jsnext: true, preferBuiltins: true, browser: true }),
+  rollupResolve({ jsnext: true, preferBuiltins: true, browser: true, modulesOnly: true }),
 
   // to include, when not external, non-esmodules packages (axios and qs e.g)
   rollupCommonjs(),


### PR DESCRIPTION
In this PR I am adding exports in package.json.

This request came through the task below:
[INT-247 - JS:  add exports fields in package.json](https://storyblok.atlassian.net/browse/INT-247)

To test, download the branch on your machine and run the commands:
```
npm run build 
npm run test
```
Any questions I'm available!