### PR TITLE
fix(types): add default_full_slug to StoryData

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -127,6 +127,8 @@ export interface StoryData<
     name: string | null;
     lang: StoryData["lang"];
   }[];
+  /** only present with translated_slugs */
+  default_full_slug?: string;
   sort_by_date: string | null;
   tag_list: string[];
   uuid: string;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Really similar to https://github.com/storyblok/storyblok-js-client/pull/127 , if you are using the [Translatable Slugs](https://www.storyblok.com/apps/translatable-slugs) app in your project your stories will have an additional property that is not currently typed on this library.

The goal of this PR is to make `StoryData` complete by adding the missing field (which is optional, such as `translated_slugs`)

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

You can check this by getting a story in a project with Translated Slugs.
