### PR TITLE
chore(deps): move prettier & rollup-plugin-mjs-entry to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,12 @@
 {
   "name": "storyblok-js-client",
-  "version": "0.0.0-development",
+  "version": "4.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "storyblok-js-client",
-      "version": "0.0.0-development",
-      "dependencies": {
-        "prettier": "^2.5.1",
-        "rollup-plugin-mjs-entry": "^0.1.1"
-      },
+      "version": "4.5.2",
       "devDependencies": {
         "@babel/core": "^7.11.6",
         "@babel/plugin-transform-runtime": "^7.11.5",
@@ -29,8 +25,10 @@
         "husky": "^7.0.4",
         "jest": "^26.4.2",
         "npm-run-all": "^4.1.5",
+        "prettier": "^2.5.1",
         "rimraf": "^3.0.2",
         "rollup": "^2.68.0",
+        "rollup-plugin-mjs-entry": "^0.1.1",
         "rollup-plugin-terser": "^7.0.2"
       },
       "peerDependencies": {
@@ -9601,6 +9599,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -10180,7 +10179,8 @@
     "node_modules/rollup-plugin-mjs-entry": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-mjs-entry/-/rollup-plugin-mjs-entry-0.1.1.tgz",
-      "integrity": "sha512-uii0Txyrn4YCgP++fypLqsT3LgO3Fx0gAZLZlWRSwKCuZ+bdSzAzdVbJFATmCHcBNlO61i65EgemOVdVQYONHA=="
+      "integrity": "sha512-uii0Txyrn4YCgP++fypLqsT3LgO3Fx0gAZLZlWRSwKCuZ+bdSzAzdVbJFATmCHcBNlO61i65EgemOVdVQYONHA==",
+      "dev": true
     },
     "node_modules/rollup-plugin-terser": {
       "version": "7.0.2",
@@ -19317,7 +19317,8 @@
     "prettier": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true
     },
     "pretty-format": {
       "version": "26.6.2",
@@ -19764,7 +19765,8 @@
     "rollup-plugin-mjs-entry": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-mjs-entry/-/rollup-plugin-mjs-entry-0.1.1.tgz",
-      "integrity": "sha512-uii0Txyrn4YCgP++fypLqsT3LgO3Fx0gAZLZlWRSwKCuZ+bdSzAzdVbJFATmCHcBNlO61i65EgemOVdVQYONHA=="
+      "integrity": "sha512-uii0Txyrn4YCgP++fypLqsT3LgO3Fx0gAZLZlWRSwKCuZ+bdSzAzdVbJFATmCHcBNlO61i65EgemOVdVQYONHA==",
+      "dev": true
     },
     "rollup-plugin-terser": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -56,16 +56,14 @@
     "husky": "^7.0.4",
     "jest": "^26.4.2",
     "npm-run-all": "^4.1.5",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.68.0",
+    "rollup-plugin-mjs-entry": "^0.1.1",
     "rollup-plugin-terser": "^7.0.2"
   },
   "peerDependencies": {
     "axios": "^0.27.2"
-  },
-  "dependencies": {
-    "prettier": "^2.5.1",
-    "rollup-plugin-mjs-entry": "^0.1.1"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
Move `prettier` & `rollup-plugin-mjs-entry` to devDependencies so they won't be installed after distributed as a package

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other (please describe): Optimization

## How to test this PR

* Run `npm pack` to build this into a tarball, say `storyblok-js-client-4.5.2.tgz`
* Create a new project and init with `npm init -y`
* Install from tarball `npm i /path/to/storyblok-js-client-4.5.2.tgz`
* `prettier` and `rollup-plugin-mjs-entry` should no longer be in `package-lock.json` or `node_modules`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Other information

The `package-lock.json` seems to be out of sync with `package.json`
And the `yarn.lock` won't be affected by this change.