### PR TITLE
add type for filter query operation `is`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -172,6 +172,7 @@ export interface FilterQueryOperations {
   in?: string;
   /** Comma-separated list */
   in_array?: string;
+  is?: string;
   like?: string;
   lt_date?: string;
   lt_float?: number;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

Better typescript support

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Prior to this using the filterquery operation `is` results in a type error
- 
- 

## Other information
