### PR TITLE
Prevent memory leaks when resolving relations/links

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,3 @@
-root = true
-
 [*]
 charset = utf-8
 end_of_line = lf

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ test.js
 test.ts
 test-manager.js
 dist/
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test.js
 test.ts
 test-manager.js
 dist/
+.idea

--- a/source/index.js
+++ b/source/index.js
@@ -51,6 +51,10 @@ class Storyblok {
     this.maxRetries = config.maxRetries || 5;
     this.throttle = throttledQueue(this.throttledRequest, rateLimit, 1000);
     this.accessToken = config.accessToken;
+    // This counter keeps track of requests that are using the resolve_relations or links features
+    // The resolve id created during the request ensures that the fetched relation/link stories can be deleted
+    // after the request is complete, otherwise this would result in a memory leak.
+    this.resolveCount = 0;
     this.relations = {};
     this.links = {};
     this.cache = config.cache || { clear: "manual" };
@@ -180,7 +184,7 @@ class Storyblok {
     return JSON.parse(JSON.stringify(value));
   }
 
-  _insertLinks(jtree, treeItem) {
+  _insertLinks(jtree, treeItem, resolveId) {
     const node = jtree[treeItem];
 
     if (
@@ -188,30 +192,30 @@ class Storyblok {
       node.fieldtype == "multilink" &&
       node.linktype == "story" &&
       typeof node.id === "string" &&
-      this.links[node.id]
+      this.links[resolveId][node.id]
     ) {
-      node.story = this._cleanCopy(this.links[node.id]);
+      node.story = this._cleanCopy(this.links[resolveId][node.id]);
     } else if (
       node &&
       node.linktype === "story" &&
       typeof node.uuid === "string" &&
-      this.links[node.uuid]
+      this.links[resolveId][node.uuid]
     ) {
-      node.story = this._cleanCopy(this.links[node.uuid]);
+      node.story = this._cleanCopy(this.links[resolveId][node.uuid]);
     }
   }
 
-  _insertRelations(jtree, treeItem, fields) {
+  _insertRelations(jtree, treeItem, fields, resolveId) {
     if (fields.indexOf(jtree.component + "." + treeItem) > -1) {
       if (typeof jtree[treeItem] === "string") {
-        if (this.relations[jtree[treeItem]]) {
-          jtree[treeItem] = this._cleanCopy(this.relations[jtree[treeItem]]);
+        if (this.relations[resolveId][jtree[treeItem]]) {
+          jtree[treeItem] = this._cleanCopy(this.relations[resolveId][jtree[treeItem]]);
         }
       } else if (jtree[treeItem].constructor === Array) {
         let stories = [];
         jtree[treeItem].forEach((uuid) => {
-          if (this.relations[uuid]) {
-            stories.push(this._cleanCopy(this.relations[uuid]));
+          if (this.relations[resolveId][uuid]) {
+            stories.push(this._cleanCopy(this.relations[resolveId][uuid]));
           }
         });
         jtree[treeItem] = stories;
@@ -232,7 +236,7 @@ class Storyblok {
     })
   }
 
-  iterateTree(story, fields) {
+  iterateTree(story, fields, resolveId) {
     let enrich = (jtree) => {
       if (jtree == null) {
         return;
@@ -247,8 +251,8 @@ class Storyblok {
         }
         for (let treeItem in jtree) {
           if ((jtree.component && jtree._uid) || jtree.type === "link") {
-            this._insertRelations(jtree, treeItem, fields);
-            this._insertLinks(jtree, treeItem);
+            this._insertRelations(jtree, treeItem, fields, resolveId);
+            this._insertLinks(jtree, treeItem, resolveId);
           } else if ('id' in jtree && jtree.fieldtype === "asset") {
             this._insertAssetsRelations(jtree, fields);
           }
@@ -260,7 +264,7 @@ class Storyblok {
     enrich(story.content);
   }
 
-  async resolveLinks(responseData, params) {
+  async resolveLinks(responseData, params, resolveId) {
     let links = [];
 
     if (responseData.link_uuids) {
@@ -290,11 +294,11 @@ class Storyblok {
     }
 
     links.forEach((story) => {
-      this.links[story.uuid] = { ...story, ...{ _stopResolving: true } };
+      this.links[resolveId][story.uuid] = { ...story, ...{ _stopResolving: true } };
     });
   }
 
-  async resolveRelations(responseData, params) {
+  async resolveRelations(responseData, params, resolveId) {
     let relations = [];
 
     if (responseData.rel_uuids) {
@@ -324,35 +328,41 @@ class Storyblok {
     }
 
     relations.forEach((story) => {
-      this.relations[story.uuid] = { ...story, ...{ _stopResolving: true } };
+      this.relations[resolveId][story.uuid] = { ...story, ...{ _stopResolving: true } };
     });
   }
 
-  async resolveStories(responseData, params) {
+  async resolveStories(responseData, params, resolveId) {
     let relationParams = [];
+
+    this.links[resolveId] = {};
+    this.relations[resolveId] = {};
 
     if (typeof params.resolve_relations !== 'undefined' && params.resolve_relations.length > 0 && (responseData.rels || responseData.rel_uuids)) {
       relationParams = params.resolve_relations.split(',')
-      await this.resolveRelations(responseData, params)
+      await this.resolveRelations(responseData, params, resolveId)
     }
 
     if (["1", "story", "url"].indexOf(params.resolve_links) > -1 && (responseData.links || responseData.link_uuids)) {
-      await this.resolveLinks(responseData, params);
+      await this.resolveLinks(responseData, params, resolveId);
     }
 
     if (this.resolveNestedRelations) {
-      for (const relUuid in this.relations) {
-        this.iterateTree(this.relations[relUuid], relationParams)
+      for (const relUuid in this.relations[resolveId]) {
+        this.iterateTree(this.relations[resolveId][relUuid], relationParams, resolveId)
       }
     }
 
     if (responseData.story) {
-      this.iterateTree(responseData.story, relationParams);
+      this.iterateTree(responseData.story, relationParams, resolveId);
     } else {
       responseData.stories.forEach((story) => {
-        this.iterateTree(story, relationParams);
+        this.iterateTree(story, relationParams, resolveId);
       });
     }
+
+    delete this.links[resolveId];
+    delete this.relations[resolveId];
   }
 
   resolveAssetsRelations(response) {
@@ -411,7 +421,10 @@ class Storyblok {
         }
 
         if (response.data.story || response.data.stories) {
-          await this.resolveStories(response.data, params);
+          // Create a new resolve id and reset the resolve counter to 0 once it reaches 10000
+          const resolveId = this.resolveCount = ++this.resolveCount % 10000;
+
+          await this.resolveStories(response.data, params, resolveId);
         }
 
         if (params.version === "published" && url != "/cdn/spaces/me") {


### PR DESCRIPTION
Hey there,

the Storyblok JS client causes massive memory leaks and performance degradation when using the `resolve_relations` or `resolve_links` feature, because the client keeps references of each fetched story in an object ([relations](https://github.com/storyblok/storyblok-js-client/blob/46945964b54fbd4903015b3743d15c335710befe/source/index.js#L54) or [links](https://github.com/storyblok/storyblok-js-client/blob/46945964b54fbd4903015b3743d15c335710befe/source/index.js#L55)), without clearing them.


## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

You can use the following test script along with the `package.json`, to check the current implementation and the changes from this pull request. Make sure to use the correct package `storyblok-js-client` or `storyblok-js-client-fix` for each test and make sure that the fetched pages have links and/or relations configured in SB. Run the script as follows and then connect to node using the chrome dev tools via `chrome://inspect` in order to record an _Allocation instrumentation timeline_ or just watch the `--trace-gc` outputs: 

```bash
node --inspect --trace-gc index.js
```

<details>
  <summary>Show test script & package.json</summary>

```json
{
  "name": "sb-test",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "dependencies": {
    "storyblok-js-client": "4.5.6",
    "storyblok-js-client-fix": "https://github.com/Schinkentanz/storyblok-js-client#3059606",
  }
}

```

```js
// const Storyblok = require('storyblok-js-client');
const Storyblok = require('storyblok-js-client-fix');

const resolveRelations = '<redacted>';

const storyblok = new Storyblok({
  accessToken: '<redacted>'
});

(async () => {
  // Give dev 10s to connect to dev tools
  await new Promise(resolve => setTimeout(resolve, 10000));

  for (let index = 0; index < 150; index++) {
    const memoryUsageBefore = memory();

    await storyblok.getStories({
      resolve_links: 'story',
      starts_with: '<redacted>',
      filter_query: {
        component: { in: '<redacted>' }
      },
      resolve_relations: resolveRelations,
      page: index + 1,
      per_page: 100
    });

    const memoryUsageAfter = memory();

    // eslint-disable-next-line
    console.log(`request: ${index} | heap: ${memoryUsageBefore} -> ${memoryUsageAfter} MB`);
  }

  // Keep process & storyblok instance alive for further investigations
  await new Promise(resolve => setTimeout(() => {
    resolve(storyblok);
  }, 1000000));
})();

function memory() {
  return (process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2);
}
```
</details>

## What is the new behavior?
With the current version, the memory won't be freed (see blue columns that are indicating stuff that is kept in memory) and we end up with `~93 MB` of used memory (killed the script before reaching 150 reqs. because it would take forever)
![Pasted Graphic 2](https://user-images.githubusercontent.com/1647548/186907195-1fd30b35-59f4-42ce-a037-69e76835091c.png)

With the pull request changes, the memory will be freed once a request is completed which results in around `~6.5 MB` of data being kept in memory:
![image](https://user-images.githubusercontent.com/1647548/186911608-3033dd4d-46db-4e34-a592-3eb3a70feb25.png)
