### PR TITLE
fix(types): add default_full_slug to ISbStoryData

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -89,6 +89,7 @@ export interface ISbStoryData<
 	first_published_at: string | null
 	slug: string
 	lang: string
+	default_full_slug?: string
 	translated_slugs?: {
 		path: string
 		name: string | null


### PR DESCRIPTION
Not sure when it disappeared since it was introduced with https://github.com/storyblok/storyblok-js-client/pull/219 but the fact is that now StoryData doesn't contain `default_full_slug` when, in fact, it's a possible field when using the Translated Slugs app.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

You can check this by getting a story in a project with Translated Slugs.

## What is the new behavior?

StoryData now includes an optional `default_full_slug`
