### PR TITLE
fix(types): add content_type to ISbStoriesParams

### DIFF
--- a/types/interfaces.d.ts
+++ b/types/interfaces.d.ts
@@ -33,6 +33,7 @@ export interface ISbStoriesParams {
     size?: string;
     datasource?: string;
     dimension?: string;
+    content_type?: string;
 }
 export interface ISbStoryParams {
     token?: string;


### PR DESCRIPTION
[According to the documentation](https://www.storyblok.com/docs/api/content-delivery/v2#core-resources/stories/retrieve-multiple-stories), we can query stories by content type with the `content_type` query parameter.
Currently, the typescript interface doesn't include it.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

