### PR TITLE
fix(types): add content_type to ISbStoriesParams

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -33,6 +33,7 @@ export interface ISbStoriesParams {
 	size?: string
 	datasource?: string
 	dimension?: string
+	content_type?: string
 }
 
 export interface ISbStoryParams {


### PR DESCRIPTION
I opened https://github.com/storyblok/storyblok-js-client/pull/361/files a few days ago but it seems the edit was in the wrong file 😬 sorry about that.

This repo has a `types` in the root that's duplicating the type definitions from `src` but it seems that it doesn't have any impact in the `dist`. I wonder if it should be removed.

Anyway, this PR does exactly the same thing as the other one, but now in the correct file.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## What is the new behavior?
`ISbStoriesParams` now contains an optional `content_type` param.