### PR TITLE
fix(int-741): Error when the user are fetching data from published links

### DIFF
--- a/src/sbFetch.ts
+++ b/src/sbFetch.ts
@@ -28,7 +28,7 @@ class SbFetch {
 	public constructor($c: ISbFetch) {
 		this.baseURL = $c.baseURL
 		this.headers = $c.headers || []
-		this.timeout = $c.timeout ? $c.timeout * 1000 : 1000
+		this.timeout = $c?.timeout ? $c.timeout * 1000 : 0
 		this.responseInterceptor = $c.responseInterceptor
 		this.fetch = (...args) => ($c.fetch ? $c.fetch(...args) : fetch(...args))
 		this.ejectInterceptor = false
@@ -104,7 +104,12 @@ class SbFetch {
 		const controller = new AbortController()
 		const { signal } = controller
 
-		const timeout = setTimeout(() => controller.abort(), this.timeout)
+		let timeout
+
+		if (this.timeout) {
+			timeout = setTimeout(() => controller.abort(), this.timeout)
+		}
+		
 
 		try {
 			const response = await this.fetch(`${url}`, {
@@ -114,7 +119,9 @@ class SbFetch {
 				signal,
 			})
 
-			clearTimeout(timeout)
+			if (this.timeout) {
+				clearTimeout(timeout)
+			}
 
 			const res = (await this._responseHandler(response)) as ISbResponse
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -89,3 +89,15 @@ describe('test constructor', () => {
 		expect(Storyblok.richTextResolver).toBeInstanceOf(RichtextResolver)
 	})
 })
+
+describe('Test for cdn/links with simultaneous requests', () => {
+	test('should not abort any of the requests', async () => {
+		for (let index = 0; index < 20; index++) {
+			await Storyblok.get('cdn/links')
+				.then((res) => {
+					expect(res.data.links).toBeTruthy()
+				})
+				.catch()
+		}
+	})
+})


### PR DESCRIPTION
DON'T MERGE BEFORE THE QA APROVE

## Pull request type

Jira Link: [INT-741](https://storyblok.atlassian.net/browse/INT-741)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix

## How to test this PR

You could create a js file and import the js-client, (This specific branch), and run the file bellow:

#### The error only happens with multiple requests so to get a good test case I added this for with 30 simultaneous requests, if you run this script with v5 you will notice that several requests will be aborted, and with this branch requests are no longer aborted

```js
const StoryblokClient = require('storyblok-js-client')

let sbApi = new StoryblokClient({
  accessToken: 'LQUIllrMLaXARdVTG2Fp2Qtt',
  // timeout: 1,
})

for (let index = 0; index < 30; index++) {
    sbApi.get('cdn/links', {
	  version: 'draft',
    })
    .then((response) => {
      console.log('Works! =>', index)
    })
    .catch((error) => {
      console.log('Error =>', index, error)
    })
}
```

## What is the new behavior?

- Now the abort function that aborted the requests only works if the user passes timeout in the settings

## Other information

### A success message from the script above

<img width="580" alt="Screenshot 2023-01-11 at 08 52 14" src="https://user-images.githubusercontent.com/40925579/211808867-3316d604-1132-4285-8253-60cae29ef478.png">

A error message from the script above

<img width="658" alt="Screenshot 2023-01-11 at 08 56 13" src="https://user-images.githubusercontent.com/40925579/211808894-dfa989f6-ebff-49ae-b5cb-8fe616912180.png">





[INT-741]: https://storyblok.atlassian.net/browse/INT-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ