### PR TITLE
fix(int 760): path value inside storydata interface

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -93,6 +93,7 @@ export interface ISbStoryData<
 	slug: string
 	lang: string
 	default_full_slug?: string
+	path?: string
 	translated_slugs?: {
 		path: string
 		name: string | null

--- a/src/sbFetch.ts
+++ b/src/sbFetch.ts
@@ -109,7 +109,6 @@ class SbFetch {
 		if (this.timeout) {
 			timeout = setTimeout(() => controller.abort(), this.timeout)
 		}
-		
 
 		try {
 			const response = await this.fetch(`${url}`, {


### PR DESCRIPTION
- Added path value to ISbStoryData inaterface.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-760](https://storyblok.atlassian.net/browse/INT-760)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
You can instantiate a new constructor and pass `path` as a response's parameter, like:
`await storyBlokClient.get('cdn/stories', { ...params })` 

where

`params = {
...
path = '/'
}`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- One can pass a `path` value to the `ISbStoryData` interface when resolving api calls from the client side.

## Other information


[INT-760]: https://storyblok.atlassian.net/browse/INT-760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ