### PR TITLE
fix(int 669): fetch issue

### DIFF
--- a/src/sbFetch.ts
+++ b/src/sbFetch.ts
@@ -91,15 +91,20 @@ class SbFetch {
 	}
 
 	private async _methodHandler(method: Method): Promise<ISbResponse | Error> {
-		const url = new URL(`${this.baseURL}${this.url}`)
+		let urlString = `${this.baseURL}${this.url}}`
+
 		let body = null
 
 		if (method === 'get') {
 			const helper = new SbHelpers()
-			url.search = helper.stringify(this.parameters)
+			urlString = `${this.baseURL}${this.url}?${helper.stringify(
+				this.parameters
+			)}`
 		} else {
 			body = JSON.stringify(this.parameters)
 		}
+
+		const url = new URL(urlString)
 
 		const controller = new AbortController()
 		const { signal } = controller


### PR DESCRIPTION
- Removed url.search wrong set

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-669](https://storyblok.atlassian.net/browse/INT-669)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

You can test in other environments but this fix is ​​specific to reactive-native, below in the comments you can see a photo showing how it works.

To know if it works or not, just make a get request.

## What is the new behavior?

- The same
-
-

## Other information


[INT-669]: https://storyblok.atlassian.net/browse/INT-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ