### PR TITLE
Revert return type of the _statusHandler back to a plain value from a promise

### DIFF
--- a/src/sbFetch.ts
+++ b/src/sbFetch.ts
@@ -150,22 +150,20 @@ class SbFetch {
 		this.ejectInterceptor = true
 	}
 
-	private _statusHandler(res: ISbResponse): Promise<ISbResponse | ISbError> {
+	private _statusHandler(res: ISbResponse) {
 		const statusOk = /20[0-6]/g
 
-		return new Promise((resolve, reject) => {
-			if (statusOk.test(`${res.status}`)) {
-				return resolve(res)
-			}
+		if (statusOk.test(`${res.status}`)) {
+			return res
+		}
+		
+		const error: ISbError = {
+			message: new Error(res.statusText),
+			status: res.status,
+			response: res.data.error || res.data.slug,
+		}
 
-			const error: ISbError = {
-				message: new Error(res.statusText),
-				status: res.status,
-				response: res.data.error || res.data.slug,
-			}
-
-			reject(error)
-		})
+		throw error;
 	}
 }
 


### PR DESCRIPTION
## Pull request type

Issue: https://github.com/storyblok/storyblok-js-client/issues/424

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

You can follow the steps mentioned in the issue.

## What is the new behavior?

Retrieving a non existent story from with the js client should throw an error that can be caught.

