### PR TITLE
chore: client config params updated in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ We added retro-compatibility when using `resolve_assets: 1` parameter under V2. 
 **Parameters**
 
 - `config` Object
-  - `accessToken` String, The preview token you can find in your space dashboard at https://app.storyblok.com
-  - `cache` Object
-    - `type` String, `none` or `memory`
+  - (`accessToken` String, optional - The preview token you can find in your space dashboard at https://app.storyblok.com. This is mandatory only if you are using the CDN API.)
+  - (`oauthToken` String, optional - The personal access token you can find in your account at https://app.storyblok.com/#/me/account?tab=token. This is mandatory only if you are using the Management API.)
+  - (`cache` Object, optional)
+    - (`type` String, optional - `none` or `memory`)
   - (`responseInterceptor` Function, optional - You can pass a function and return the result. For security reasons, Storyblok client will deal only with the response interceptor.)
   - (`region` String, optional)
   - (`https` Boolean, optional)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Chore. I have no Jira link since it's just a small thing reported by @johannes-lindgren to me

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other (please describe): Readme update

## How to test this PR

Review the content of the readme file.

## What is the new behavior?

I updated the readme file as the `config` parameters. The `oauthToken` parameter was missing. The `cache` parameter is actually optional so I updated it. The `accessToken` and oauthToken` are optional but at leas one of them is required so I updated both to be optional with the note that the first is mandatory for the CDN API only and the second one for the MAPI only. 
