### PR TITLE
task(int-729): adding support for china region

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,13 +82,13 @@ class Storyblok {
 	 */
 	public constructor(config: ISbConfig, endpoint?: string) {
 		if (!endpoint) {
-			const region = config.region ? `-${config.region}` : ''
+			const getRegion = new SbHelpers().getRegionURL
 			const protocol = config.https === false ? 'http' : 'https'
 
 			if (!config.oauthToken) {
-				endpoint = `${protocol}://api${region}.storyblok.com/${'v2' as Version}`
+				endpoint = `${protocol}://${getRegion(config.region)}/${'v2' as Version}`
 			} else {
-				endpoint = `${protocol}://api${region}.storyblok.com/${'v1' as Version}`
+				endpoint = `${protocol}://${getRegion(config.region)}/${'v1' as Version}`
 			}
 		}
 

--- a/src/sbHelpers.ts
+++ b/src/sbHelpers.ts
@@ -76,4 +76,24 @@ export class SbHelpers {
 		}
 		return pairs.join('&')
 	}
+
+	/**
+	 * @method getRegionURL
+	 * @param  {String} regionCode region code, could be eu, us or cn
+	 * @return {String} The base URL of the region
+	 */
+	public getRegionURL(regionCode?: string): string {
+		const EU_API_URL = 'api.storyblok.com'
+		const US_API_URL = 'api-us.storyblok.com'
+		const CN_API_URL = 'app.storyblokchina.cn'
+
+		switch (regionCode) {
+			case 'us':
+				return US_API_URL
+			case 'cn':
+				return CN_API_URL
+			default:
+				return EU_API_URL
+		}
+	}
 }

--- a/tests/units/helpers.test.js
+++ b/tests/units/helpers.test.js
@@ -91,3 +91,30 @@ describe('flatMap function', () => {
 		expect(helpers.flatMap([0, 2], (v) => [v, v + 1])).toEqual([0, 1, 2, 3])
 	})
 })
+
+describe('getRegionURL function', () => {
+	const EU_API_URL = 'api.storyblok.com'
+	const US_API_URL = 'api-us.storyblok.com'
+	const CN_API_URL = 'app.storyblokchina.cn'
+
+	test('should return the europe url when pass a empty string', () => {
+		expect(helpers.getRegionURL('')).toEqual(EU_API_URL)
+	})
+
+	test('should return the europe url when pass non supported region code', () => {
+		expect(helpers.getRegionURL('nn')).toEqual(EU_API_URL)
+	})
+
+	test('should return the europe url when pass eu string', () => {
+		expect(helpers.getRegionURL('eu')).toEqual(EU_API_URL)
+	})
+
+	test('should return the united states url when pass us string', () => {
+		expect(helpers.getRegionURL('us')).toEqual(US_API_URL)
+	})
+
+	test('should return the china url when pass cn string', () => {
+		expect(helpers.getRegionURL('cn')).toEqual(CN_API_URL)
+	})
+
+})


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-729](https://storyblok.atlassian.net/browse/INT-729)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Feature

## How to test this PR

To test in Chinese spaces you only need to pass the region code 'cn', like in the example bellow:

```js
  const sbApi = new StoryblokClient({
    accessToken: 'YOUR_ACCESS_TOKEN',
    region: 'cn', // to China is 'cn', United States 'us' and to Europe 'eu'
    version: "draft", // optional
  })

  sbApi.get(`cdn/stories`, { version: 'draft' })
    .then(({ data }) => {
      console.log(`Works in China =>`, data.stories)
    })
    .catch((error) => {
      console.log('Error =>', error)
    })
```

## What is the new behavior?

- Now it's possible to use the SDK with Chinese spaces 😄 

## Other information


[INT-729]: https://storyblok.atlassian.net/browse/INT-729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ