### PR TITLE
[feat] add option to automatically optimize images with SB Image Service

### DIFF
--- a/src/richTextResolver.ts
+++ b/src/richTextResolver.ts
@@ -5,6 +5,10 @@ type HtmlEscapes = {
 	[key: string]: string
 }
 
+type RenderOptions = { 
+	optimizeImages: boolean 
+}
+
 const escapeHTML = function (string: string) {
 	const htmlEscapes = {
 		'&': '&amp;',
@@ -51,13 +55,16 @@ class RichTextResolver {
 		this.marks[key] = schema
 	}
 
-	public render(data?: ISbRichtext) {
+	public render(data?: ISbRichtext, options: RenderOptions = { optimizeImages: false } ) {
 		if (data && data.content && Array.isArray(data.content)) {
 			let html = ''
 
 			data.content.forEach((node) => {
 				html += this.renderNode(node)
 			})
+
+			if (options.optimizeImages)
+				return html.replace(/a.storyblok.com\/f\/(\d+)\/([^.]+)\.(gif|jpg|jpeg|png|tif|tiff|bmp)/g, "a.storyblok.com/f/$1/$2.$3/m/")
 
 			return html
 		}

--- a/tests/richTextResolver.test.js
+++ b/tests/richTextResolver.test.js
@@ -90,6 +90,22 @@ test('image to generate img tag', () => {
 	expect(resolver.render(doc)).toBe('<img src="https://asset" />')
 })
 
+test('image to generate img tag with optimization', () => {
+	const doc = {
+		type: 'doc',
+		content: [
+			{
+				type: 'image',
+				attrs: {
+					src: 'https://a.storyblok.com/f/000000/00a00a00a0/image-name.png',
+				},
+			},
+		],
+	}
+
+	expect(resolver.render(doc, { optimizeImages: true })).toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+})
+
 test('link to generate a tag', () => {
 	const doc = {
 		type: 'doc',


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

After migrate hundred posts from WP to SB I noticed that a lot of posts has images inside richtext field and with sizes starting from 1MB. Each of these blog posts has ~7mb images in total. This PR adds an option to the render method to automatically return optimized version of images inside the richtext content fields.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
- `npm run test`
- Get a story object with richtext field that contains images and use `Storyblok.richTextResolver.render` function with a second parameter `{ optimizeImages: true }`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Using `Storyblok.richTextResolver.render(story.content.my_rich_text_field, { optimizeImages: true })` all images will be returned with `/m/` sufix in their filepath.

## Other information

I think this should be the default behavior but I let it disabled by default for now.