### PR TITLE
feat(int 841): Adding support for anchor in the richtext resolver

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -199,6 +199,7 @@ export interface ISbError {
 }
 
 export interface ISbNode extends Element {
+	content: any
 	attrs: {
 		anchor?: string
 		body: Array<ISbComponentType<any>>

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -55,6 +55,7 @@ const heading: NodeSchema = (node: ISbNode) => {
 		tag: `h${node.attrs.level}`,
 	}
 }
+
 const image: NodeSchema = (node: ISbNode) => {
 	return {
 		singleTag: [
@@ -157,6 +158,7 @@ const link: MarkSchema = (node: ISbNode) => {
 		],
 	}
 }
+
 const styled: MarkSchema = (node: ISbNode) => {
 	return {
 		tag: [
@@ -177,6 +179,17 @@ const subscript: MarkSchema = () => {
 const superscript: MarkSchema = () => {
 	return {
 		tag: 'sup'
+	}
+}
+
+const anchor: MarkSchema = (node: ISbNode) => {
+	return {
+		tag: [
+			{
+				tag: 'span',
+				attrs: node.attrs,
+			},
+		],
 	}
 }
 
@@ -205,5 +218,6 @@ export default {
 		styled,
 		subscript,
 		superscript,
+		anchor
 	},
 }

--- a/tests/constants/richTextResolver.js
+++ b/tests/constants/richTextResolver.js
@@ -351,3 +351,57 @@ export const LONG_TEXT_WITH_LINKS_SUB_SUP_SCRIPTS = {
     }
   ]
 }
+
+export const PARAGRAPH_WITH_ANCHOR_IN_THE_MIDDLE = {
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "text": "a long text with a super nice ",
+          "type": "text"
+        },
+        {
+          "text": "anchor here",
+          "type": "text",
+          "marks": [
+            {
+              "type": "anchor",
+              "attrs": {
+                "id": "test2"
+              }
+            }
+          ]
+        },
+        {
+          "text": ", and at the end of the text is a normal tag",
+          "type": "text"
+        }
+      ]
+    }
+  ]
+}
+
+export const PARAGRAPH_WITH_ANCHOR = {
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "text": "Paragraph with anchor in the midle",
+          "type": "text",
+          "marks": [
+            {
+              "type": "anchor",
+              "attrs": {
+                "id": "test"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/richTextResolver.test.js
+++ b/tests/richTextResolver.test.js
@@ -321,3 +321,44 @@ test('should render a text with links, subscripts and superscripts', () => {
 
 	expect(result).toBe(expected)
 })
+
+test('should render a h1 title with a anchor in the midlle of the text', () => {
+	const sentenceWithAnchor = {
+		type: 'doc',
+		content: [
+			{
+				type: 'heading',
+				attrs: {
+					level: '1'
+				},
+				content: [
+					{
+						text: 'Title with ',
+						type: 'text'
+					},
+					{
+						text: 'Anchor',
+						type: 'text',
+						marks: [
+							{
+								type: 'anchor',
+								attrs: {
+									id: 'test1'
+								}
+							}
+						]
+					},
+					{
+						text: ' in the midle',
+						type: 'text'
+					}
+				]
+			}
+		]
+	}
+
+	const result = resolver.render(sentenceWithAnchor)
+	const expected = '<h1>Title with <span id="test1">Anchor</span> in the midle</h1>'
+
+	expect(result).toBe(expected)
+})

--- a/tests/richTextResolver.test.js
+++ b/tests/richTextResolver.test.js
@@ -11,6 +11,8 @@ import {
 	CUSTOM_ATTRIBUTE_DATA,
 	LONG_TEXT_WITH_LINKS_SUB_SUP_SCRIPTS,
 	LINK_WITH_ANCHOR_FOR_CUSTOM_SCHEMA,
+	PARAGRAPH_WITH_ANCHOR_IN_THE_MIDDLE,
+	PARAGRAPH_WITH_ANCHOR,
 } from './constants/richTextResolver'
 
 const TOKEN = 'w0yFvs04aKF2rpz6F8OfIQtt'
@@ -359,6 +361,20 @@ test('should render a h1 title with a anchor in the midlle of the text', () => {
 
 	const result = resolver.render(sentenceWithAnchor)
 	const expected = '<h1>Title with <span id="test1">Anchor</span> in the midle</h1>'
+
+	expect(result).toBe(expected)
+})
+
+test('should render a anchor in the text', () => {
+	const result = resolver.render(PARAGRAPH_WITH_ANCHOR)
+	const expected = '<p><span id="test">Paragraph with anchor in the midle</span></p>'
+
+	expect(result).toBe(expected)
+})
+
+test('should render a anchor in the middle of a text', () => {
+	const result = resolver.render(PARAGRAPH_WITH_ANCHOR_IN_THE_MIDDLE)
+	const expected = '<p>a long text with a super nice <span id="test2">anchor here</span>, and at the end of the text is a normal tag</p>'
 
 	expect(result).toBe(expected)
 })

--- a/tests/richTextResolver.test.js
+++ b/tests/richTextResolver.test.js
@@ -324,7 +324,7 @@ test('should render a text with links, subscripts and superscripts', () => {
 	expect(result).toBe(expected)
 })
 
-test('should render a h1 title with a anchor in the midlle of the text', () => {
+test('should render a h1 title with a anchor in the middle of the text', () => {
 	const sentenceWithAnchor = {
 		type: 'doc',
 		content: [


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-841](https://storyblok.atlassian.net/browse/INT-841)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Feature

## How to test this PR

To test this you need to create a text with a anchor in [this PR](https://github.com/storyblok/storyfront/pull/3531), and to test the response of the richtext, you can use this platform https://js-client-richtext-resolver.surge.sh/

**In the video bellow you can see the test using [this PR](https://github.com/storyblok/storyfront/pull/3531) to generate the anchor.**

https://user-images.githubusercontent.com/40925579/224780504-4f070a64-f7cc-4c3d-b714-e511818b75e5.mov


## What is the new behavior?

- Now we have support for the anchor functionality

## Other information

- If you have issues or doubt to test it, please ping me 
