### PR TITLE
(feat) Add new options to image optimization in richtext field

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,11 +381,62 @@ Storyblok.setComponentResolver((component, blok) => {
 
 - `[return]` String, Rendered html of a richtext field
 - `data` Richtext object, An object with a `content` (an array of nodes) field.
+- `options` (optional) Options to control render behavior.
 
 **Example**
 
 ```javascript
 Storyblok.richTextResolver.render(blok.richtext)
+```
+
+**Optimizing images**
+
+You can instruct the richtext resolver to optimize images using [Storyblok Image Service](https://www.storyblok.com/docs/image-service) 
+passing the option `optimizeImages: true`. 
+
+**Example**
+
+```javascript
+Storyblok.richTextResolver.render(blok.richtext, { optimizeImages: true })
+```
+
+Also, it is possible to customize this option passing an object. 
+All properties are optional and will be applied to each image in the field.
+
+**Example**
+
+```js
+const options = { 
+  optimizeImages: {
+    class: 'w-full my-8 border-b border-black',
+    width: 640, // image width
+    height: 360, // image height
+    loading: 'lazy', // 'lazy' | 'eager'
+    filters: {
+      blur: 0, // 0 to 100
+      brightness: 0, // -100 to 100
+      fill: 'transparent', // Or any hexadecimal value like FFCC99
+      format: 'webp', // 'webp' | 'jpeg' | 'png'
+      grayscale: false,
+      quality: 95, // 0 to 100
+      rotate: 0 // 0 | 90 | 180 | 270
+    },
+    // srcset accepts an array with image widths. 
+    // Example: [720, 1024, 1533] 
+    // will render srcset="//../m/720x0 720w", "//../m/1024x0 1024w", "//../m/1533x0 1280w"
+    // Also accept an array to pass width and height. 
+    // Example: [[720,500], 1024, [1500, 1000]] 
+    // will render srcset="//../m/720x500 720w", "//../m/1024x0 1024w", "//../m/1280x0 1280w"
+    srcset: [720, 1024, 1533], 
+    sizes: [
+      '(max-width: 767px) 100vw',
+      '(max-width: 1024px) 768px',
+      '1500px'
+    ]
+  }
+}
+
+Storyblok.richTextResolver.render(blok.richtext, options)
 ```
 
 ### Code examples

--- a/src/richTextResolver.ts
+++ b/src/richTextResolver.ts
@@ -5,8 +5,28 @@ type HtmlEscapes = {
 	[key: string]: string
 }
 
-type RenderOptions = { 
-	optimizeImages: boolean 
+type OptimizeImagesOptions =
+	| boolean
+	| {
+			class?: string
+			filters?: {
+				blur?: number
+				brightness?: number
+				fill?: string
+				format?: 'webp' | 'jpeg' | 'png'
+				grayscale?: boolean
+				quality?: number
+				rotate?: 90 | 180 | 270
+			}
+			height?: number
+			loading?: 'lazy' | 'eager'
+			sizes?: string[]
+			srcset?: (number | [number, number])[]
+			width?: number
+	  }
+
+type RenderOptions = {
+	optimizeImages?: OptimizeImagesOptions
 }
 
 const escapeHTML = function (string: string) {
@@ -55,7 +75,10 @@ class RichTextResolver {
 		this.marks[key] = schema
 	}
 
-	public render(data?: ISbRichtext, options: RenderOptions = { optimizeImages: false } ) {
+	public render(
+		data?: ISbRichtext,
+		options: RenderOptions = { optimizeImages: false }
+	) {
 		if (data && data.content && Array.isArray(data.content)) {
 			let html = ''
 
@@ -63,8 +86,9 @@ class RichTextResolver {
 				html += this.renderNode(node)
 			})
 
-			if (options.optimizeImages)
-				return html.replace(/a.storyblok.com\/f\/(\d+)\/([^.]+)\.(gif|jpg|jpeg|png|tif|tiff|bmp)/g, "a.storyblok.com/f/$1/$2.$3/m/")
+			if (options.optimizeImages) {
+				return this.optimizeImages(html, options.optimizeImages)
+			}
 
 			return html
 		}
@@ -73,6 +97,145 @@ class RichTextResolver {
 			'The render method must receive an object with a content field, which is an array'
 		)
 		return ''
+	}
+
+	private optimizeImages(html: string, options: OptimizeImagesOptions): string {
+		let w = 0
+		let h = 0
+		let imageAttributes = ''
+		let filters = ''
+
+		if (typeof options !== 'boolean') {
+			if (typeof options.width === 'number' && options.width > 0) {
+				imageAttributes += `width="${options.width}" `
+				w = options.width
+			}
+
+			if (typeof options.height === 'number' && options.height > 0) {
+				imageAttributes += `height="${options.height}" `
+				h = options.height
+			}
+
+			if (options.loading === 'lazy' || options.loading === 'eager') {
+				imageAttributes += `loading="${options.loading}" `
+			}
+
+			if (typeof options.class === 'string' && options.class.length > 0) {
+				imageAttributes += `class="${options.class}" `
+			}
+
+			if (options.filters) {
+				if (
+					typeof options.filters.blur === 'number' &&
+					options.filters.blur >= 0 &&
+					options.filters.blur <= 100
+				) {
+					filters += `:blur(${options.filters.blur})`
+				}
+
+				if (
+					typeof options.filters.brightness === 'number' &&
+					options.filters.brightness >= -100 &&
+					options.filters.brightness <= 100
+				) {
+					filters += `:brightness(${options.filters.brightness})`
+				}
+
+				if (
+					options.filters.fill &&
+					(options.filters.fill.match(/[0-9A-Fa-f]{6}/g) ||
+						options.filters.fill === 'transparent')
+				) {
+					filters += `:fill(${options.filters.fill})`
+				}
+
+				if (
+					options.filters.format &&
+					['webp', 'png', 'jpeg'].includes(options.filters.format)
+				) {
+					filters += `:format(${options.filters.format})`
+				}
+
+				if (
+					typeof options.filters.grayscale === 'boolean' &&
+					options.filters.grayscale
+				) {
+					filters += ':grayscale()'
+				}
+
+				if (
+					typeof options.filters.quality === 'number' &&
+					options.filters.quality >= 0 &&
+					options.filters.quality <= 100
+				) {
+					filters += `:quality(${options.filters.quality})`
+				}
+
+				if (
+					options.filters.rotate &&
+					[90, 180, 270].includes(options.filters.rotate)
+				) {
+					filters += `:rotate(${options.filters.rotate})`
+				}
+
+				if (filters.length > 0) filters = '/filters' + filters
+			}
+		}
+
+		if (imageAttributes.length > 0) {
+			html = html.replace(/<img/g, `<img ${imageAttributes.trim()}`)
+		}
+
+		const parameters =
+			w > 0 || h > 0 || filters.length > 0 ? `${w}x${h}${filters}` : ''
+
+		html = html.replace(
+			/a.storyblok.com\/f\/(\d+)\/([^.]+)\.(gif|jpg|jpeg|png|tif|tiff|bmp)/g,
+			`a.storyblok.com/f/$1/$2.$3/m/${parameters}`
+		)
+
+		if (typeof options !== 'boolean' && (options.sizes || options.srcset)) {
+			html = html.replace(/<img.*?src=["|'](.*?)["|']/g, (value: string) => {
+				const url = value.match(
+					/a.storyblok.com\/f\/(\d+)\/([^.]+)\.(gif|jpg|jpeg|png|tif|tiff|bmp)/g
+				)
+
+				if (url && url.length > 0) {
+					const imageAttributes = {
+						srcset: options.srcset
+							?.map((value) => {
+								if (typeof value === 'number') {
+									return `//${url}/m/${value}x0${filters} ${value}w`
+								}
+
+								if (typeof value === 'object' && value.length === 2) {
+									let w = 0
+									let h = 0
+									if (typeof value[0] === 'number') w = value[0]
+									if (typeof value[1] === 'number') h = value[1]
+									return `//${url}/m/${w}x${h}${filters} ${w}w`
+								}
+							})
+							.join(', '),
+						sizes: options.sizes?.map((size) => size).join(', '),
+					}
+
+					let renderImageAttributes = ''
+					if (imageAttributes.srcset) {
+						renderImageAttributes += `srcset="${imageAttributes.srcset}" `
+					}
+					if (imageAttributes.sizes) {
+						renderImageAttributes += `sizes="${imageAttributes.sizes}" `
+					}
+
+					return value.replace(/<img/g, `<img ${renderImageAttributes.trim()}`)
+				}
+
+				return value
+			})
+		}
+
+		return html
 	}
 
 	private renderNode(item: ISbRichtext) {

--- a/tests/richTextResolver.test.js
+++ b/tests/richTextResolver.test.js
@@ -73,20 +73,147 @@ test('image to generate img tag', () => {
 	expect(resolver.render(IMAGE_DATA)).toBe('<img src="https://asset" />')
 })
 
-test('image to generate img tag with optimization', () => {
-	const doc = {
-		type: 'doc',
-		content: [
-			{
-				type: 'image',
-				attrs: {
-					src: 'https://a.storyblok.com/f/000000/00a00a00a0/image-name.png',
-				},
+const docWithImage = {
+	type: 'doc',
+	content: [
+		{
+			type: 'image',
+			attrs: {
+				src: 'https://a.storyblok.com/f/000000/00a00a00a0/image-name.png',
 			},
-		],
+		},
+	],
+}
+
+test('image to generate img tag with optimization', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: true }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+})
+
+test('image to generate img tag with optimization and loading lazy', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { loading: 'lazy' } }))
+		.toBe('<img loading="lazy" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+})
+
+test('image to generate img tag with optimization and width', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { width: 500 } }))
+		.toBe('<img width="500" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/500x0" />')
+})
+
+test('image to generate img tag with optimization and height', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { height: 350 } }))
+		.toBe('<img height="350" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x350" />')
+})
+
+test('image to generate img tag with optimization and custom class', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { class: 'w-full my-8' } }))
+		.toBe('<img class="w-full my-8" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+
+	expect(resolver.render(docWithImage, { optimizeImages: { class: '' } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+})
+
+test('image to generate img tag with optimization and filter blur', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { blur: 10 } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:blur(10)" />')
+})
+
+test('image to generate img tag with optimization and filter brightness', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { brightness: 15 } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:brightness(15)" />')
+})
+
+test('image to generate img tag with optimization and filter fill', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { fill: 'transparent' } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:fill(transparent)" />')
+
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { fill: 'FFCC99' } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:fill(FFCC99)" />')
+
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { fill: 'INVALID' } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+})
+
+test('image to generate img tag with optimization and filter format', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { format: 'png' } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:format(png)" />')
+
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { format: 'webp' } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:format(webp)" />')
+
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { format: 'jpeg' } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:format(jpeg)" />')
+
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { format: 'invalidFormat' } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+})
+
+test('image to generate img tag with optimization and filter grayscale', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { grayscale: true } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:grayscale()" />')
+})
+
+test('image to generate img tag with optimization and filter quality', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { quality: 90 } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:quality(90)" />')
+})
+
+test('image to generate img tag with optimization and filter rotate', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { rotate: 90 } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:rotate(90)" />')
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { rotate: 180 } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:rotate(180)" />')
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { rotate: 270 } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:rotate(270)" />')
+	expect(resolver.render(docWithImage, { optimizeImages: { filters: { rotate: 9999 } } }))
+		.toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+})
+
+test('image to generate img tag with optimization and srcset', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { srcset: [360, 1024, 1500] } }))
+		.toBe('<img srcset="//a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/360x0 360w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1024x0 1024w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1500x0 1500w" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+
+	expect(resolver.render(docWithImage, { optimizeImages: { srcset: [[360,360], 1024, 1500] } }))
+		.toBe('<img srcset="//a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/360x360 360w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1024x0 1024w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1500x0 1500w" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+})
+
+test('image to generate img tag with optimization and sizes', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { sizes: ['(max-width: 767px) 100vw', '(max-width: 1024px) 768px', '1500px'] } }))
+		.toBe('<img sizes="(max-width: 767px) 100vw, (max-width: 1024px) 768px, 1500px" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+})
+
+test('image to generate img tag with optimization and srcset and sizes', () => {
+	expect(resolver.render(docWithImage, { optimizeImages: { srcset: [360, 1024, 1500], sizes: ['(max-width: 767px) 100vw', '(max-width: 1024px) 768px', '1500px'] } }))
+		.toBe('<img srcset="//a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/360x0 360w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1024x0 1024w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1500x0 1500w" sizes="(max-width: 767px) 100vw, (max-width: 1024px) 768px, 1500px" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+})
+
+test('image to generate img tag with optimization and multiple options', () => {
+	const options = { 
+		optimizeImages: {
+			loading: 'lazy',
+			class: 'w-full',
+			width: 640,
+			height: 360,
+			filters: {
+			  blur: 1,
+			  brightness: 5,
+			  fill: 'transparent',
+			  format: 'webp',
+			  grayscale: true,
+			  quality: 95,
+			  rotate: 180
+			},
+			srcset: [360, 1024, 1500], 
+			sizes: [
+				'(max-width: 767px) 100vw', 
+				'(max-width: 1024px) 768px', 
+				'1500px'
+			] 
+		}
 	}
 
-	expect(resolver.render(doc, { optimizeImages: true })).toBe('<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" />')
+	expect(resolver.render(docWithImage, options))
+		.toBe('<img srcset="//a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/360x0/filters:blur(1):brightness(5):fill(transparent):format(webp):grayscale():quality(95):rotate(180) 360w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1024x0/filters:blur(1):brightness(5):fill(transparent):format(webp):grayscale():quality(95):rotate(180) 1024w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1500x0/filters:blur(1):brightness(5):fill(transparent):format(webp):grayscale():quality(95):rotate(180) 1500w" sizes="(max-width: 767px) 100vw, (max-width: 1024px) 768px, 1500px" width="640" height="360" loading="lazy" class="w-full" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/640x360/filters:blur(1):brightness(5):fill(transparent):format(webp):grayscale():quality(95):rotate(180)" />')
 })
 
 test('link to generate a tag', () => {


### PR DESCRIPTION
Hi! This PR extends #458 adding new options to customize image render and also updates the docs including related info.

With this new options is possible to resolve some Web Vitals errors like...

- Serve images in next-gen formats
- Defer offscreen images
- Image elements do not have explicit width and height
- Avoid enormous network payloads

...and use filters from [Storyblok Image Service](https://www.storyblok.com/docs/image-service) like blur, brigthness, quality etc...

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- yarn test
- create a content with a richtextfield and place images inside
- use `Storyblok.richTextResolver.render(blok.richtext, options)`

## What is the new behavior?

- Lightweight images with Storyblok Image Service
- Image tags with attributes recommended by webvitals
- Responsive images with srcset and sizes attributes

## Other information

Example with all options. All parameters are optional.

```js
const options = { 
  optimizeImages: {
    class: 'w-full my-8 border-b border-black',
    width: 640, // image width
    height: 360, // image height
    loading: 'lazy', // 'lazy' | 'eager'
    filters: {
      blur: 0, // 0 to 100
      brightness: 0, // -100 to 100
      fill: 'transparent', // Or any hexadecimal value like FFCC99
      format: 'webp', // 'webp' | 'jpeg' | 'png'
      grayscale: false,
      quality: 95, // 0 to 100
      rotate: 0 // 0 | 90 | 180 | 270
    },
    // srcset accepts an array with image widths. 
    // Example: [720, 1024, 1533] 
    // will render srcset="//../m/720x0 720w", "//../m/1024x0 1024w", "//../m/1533x0 1280w"
    // Also accept an array to pass width and height. 
    // Example: [[720,500], 1024, [1500, 1000]] 
    // will render srcset="//../m/720x500 720w", "//../m/1024x0 1024w", "//../m/1280x0 1280w"
    srcset: [720, 1024, 1533], 
    sizes: [
      '(max-width: 767px) 100vw',
      '(max-width: 1024px) 768px',
      '1500px'
    ]
  }
}

Storyblok.richTextResolver.render(blok.richtext, options)
```