### PR TITLE
feat(int 822): Full Emoji support in richtext resolver

### DIFF
--- a/src/richTextResolver.ts
+++ b/src/richTextResolver.ts
@@ -267,6 +267,8 @@ class RichTextResolver {
 			html.push(this.renderTag(node.singleTag, ' /'))
 		} else if (node && node.html) {
 			html.push(node.html)
+		} else if (item.type === 'emoji') {
+			html.push(this.renderEmoji(item))
 		}
 
 		if (node && node.tag) {
@@ -349,6 +351,26 @@ class RichTextResolver {
 		if (typeof node === 'function') {
 			return node(item)
 		}
+	}
+
+	private renderEmoji(item: ISbRichtext) {
+		if (item.attrs.emoji) {
+			return item.attrs.emoji
+		}
+
+		const emojiImageContainer = [
+			{
+				tag: 'img',
+				attrs: {
+					src: item.attrs.fallbackImage,
+					draggable: 'false',
+					loading: 'lazy',
+					align: 'absmiddle',
+				},
+			},
+		] as unknown as ISbTag[]
+
+		return this.renderTag(emojiImageContainer, ' /')
 	}
 }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -85,7 +85,8 @@ const paragraph: NodeSchema = () => {
 const emoji: NodeSchema = (node: ISbNode) => {
 	const attrs = {
 		['data-type']: 'emoji',
-		['data-name']: node.attrs.name
+		['data-name']: node.attrs.name,
+		emoji: node.attrs.emoji
 	}
 
 	return {

--- a/tests/constants/richTextResolver.js
+++ b/tests/constants/richTextResolver.js
@@ -456,3 +456,49 @@ export const BOLD_TEXT = {
     },
   ],
 }
+
+export const TEXT_WITH_EMOJI = {
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "text": "Text with a emoji in the end ",
+          "type": "text"
+        },
+        {
+          "type": "emoji",
+          "attrs": {
+            "name": "smile",
+            "emoji": "😄",
+            "fallbackImage": "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f604.png"
+          }
+        },
+      ]
+    }
+  ]
+}
+
+export const TEXT_WITH_EMOJI_VIA_FALLBACKIMAGE = {
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "text": "Text with a emoji in the end ",
+          "type": "text"
+        },
+        {
+          "type": "emoji",
+          "attrs": {
+            "name": "trollface",
+            "emoji": null,
+            "fallbackImage": "https://github.githubassets.com/images/icons/emoji/trollface.png"
+          }
+        },
+      ]
+    }
+  ]
+}

--- a/tests/richTextResolver.test.js
+++ b/tests/richTextResolver.test.js
@@ -16,6 +16,8 @@ import {
 	TEXT_COLOR_DATA,
 	HIGLIGHT_COLOR_DATA,
 	BOLD_TEXT,
+	TEXT_WITH_EMOJI,
+	TEXT_WITH_EMOJI_VIA_FALLBACKIMAGE
 } from './constants/richTextResolver'
 
 const TOKEN = 'w0yFvs04aKF2rpz6F8OfIQtt'
@@ -423,26 +425,16 @@ test('should render a superscript', () => {
 	expect(result).toBe(expected)
 })
 
-test('should render an emoji', () => {
-	const emojiData = {
-    type: 'doc',
-    content: [
-			{
-				type: 'paragraph',
-				content: [
-					{
-						type: 'emoji',
-						attrs: {
-							name: 'smiley'
-						}
-					}
-				]
-			}
-    ]
-	}
+test('should render a text with a emoji', () => {
+	const result = resolver.render(TEXT_WITH_EMOJI)
+	const expected = '<p>Text with a emoji in the end <span data-type="emoji" data-name="smile" emoji="😄">😄</span></p>'
 
-	const result = resolver.render(emojiData)
-	const expected = '<p><span data-type="emoji" data-name="smiley"></span></p>'
+	expect(result).toBe(expected)
+})
+
+test('should render a emoji with falbackimage', () => {
+	const result = resolver.render(TEXT_WITH_EMOJI_VIA_FALLBACKIMAGE)
+	const expected = '<p>Text with a emoji in the end <span data-type="emoji" data-name="trollface"><img src="https://github.githubassets.com/images/icons/emoji/trollface.png" draggable="false" loading="lazy" align="absmiddle" /></span></p>'
 
 	expect(result).toBe(expected)
 })


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-822](https://storyblok.atlassian.net/browse/INT-822)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Feature

## How to test this PR

### To create stories with emojis in the richtext content you need [access to this PR](https://github.com/storyblok/storyfront/pull/3495) to set the emojis

1. Download this branch
2. Build this branch and install in your file test bellow `yarn prepare`
3. run the code bellow, the results need to be the correct html for the new and old types

```js
import StoryblokClient from 'storyblok-js-client'

try {
  const sbApi = new StoryblokClient({
    accessToken: 'njqqM5pRfbBoBHZ2dYm4YAtt',
  })

  await sbApi.get(`cdn/stories/home`)
    .then((response) => {
      const story = response.data.story
      const RT_DATA = story.content.ritch_text // The .rich_text is the name of your richtext field inside your story
      console.log(sbApi.richTextResolver.render(RT_DATA)) // console the json parsed
    })
    .catch((error) => {
      console.log('Error =>', error)
    })
} catch (error) {
  console.log('Error try =>', error)
}
```

----

If you want, it's possible to test this branch in this link => https://js-client-richtext-resolver.surge.sh/

You only need to add your access token, story name, and the name of the richtext field

## What is the new behavior?

- Now the richtext resolver has new supports for: 
  - Emoji

## Other information


[INT-822]: https://storyblok.atlassian.net/browse/INT-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ