### PR TITLE
chore: updating text color for RichText Resolver

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -210,7 +210,7 @@ const highlight: MarkSchema = (node: ISbNode) => {
 
 const textStyle: MarkSchema = (node: ISbNode) => {
 	const attrs = {
-		['style']: `background-color:${node.attrs.color}`,
+		['style']: `color:${node.attrs.color}`,
 	}
 	return {
 		tag: [


### PR DESCRIPTION
In the Richtext field:
- selecting text color: changes the color of the text
- selecting highlight color: changes the color of the text background

Before this fix, changing highlight and text , both set the `background-color`

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

In a rich text field, try to select a text and then change the color.

## What is the new behavior?


- Highlight color : is for the background
- Text color : is for the foreground color


