### PR TITLE
doc: add missing colons in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Storyblok.getAll('cdn/stories', {
 ```javascript
 Storyblok
   .post('spaces/<YOUR_SPACE_ID>/stories', {
-    story: {name 'xy', slug: 'xy'}
+    story: {name: 'xy', slug: 'xy'}
   })
   .then((response) => {
     console.log(response);
@@ -319,7 +319,7 @@ Storyblok
 ```javascript
 Storyblok
   .put('spaces/<YOUR_SPACE_ID>/stories/1', {
-    story: {name 'xy', slug: 'xy'}
+    story: {name: 'xy', slug: 'xy'}
   })
   .then((response) => {
     console.log(response);


### PR DESCRIPTION
I've added 2 missing colons in examples in the README.md

## Pull request type

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Other (please describe): Doc

