### PR TITLE
fix(int-916): Fix problem with colors in richtext resolver

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,9 +147,11 @@ class Storyblok {
 		this.richTextResolver.addNode('blok', (node: ISbNode) => {
 			let html = ''
 
-			node.attrs.body.forEach((blok) => {
-				html += resolver(blok.component, blok)
-			})
+			if (node.attrs.body) {
+				node.attrs.body.forEach((blok) => {
+					html += resolver(blok.component, blok)
+				})
+			}
 
 			return {
 				html: html,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -202,12 +202,12 @@ export interface ISbNode extends Element {
 	content: object[]
 	attrs: {
 		anchor?: string
-		body: Array<ISbComponentType<any>>
+		body?: Array<ISbComponentType<any>>
 		href?: string
 		level?: number
 		linktype?: string
-		custom?: LinkCustomAttributes,
-		[key: string]: any,
+		custom?: LinkCustomAttributes
+		[key: string]: any | undefined
 	}
 }
 

--- a/src/richTextResolver.ts
+++ b/src/richTextResolver.ts
@@ -272,7 +272,7 @@ class RichTextResolver {
 			item.marks.forEach((m) => {
 				const mark = this.getMatchingMark(m)
 
-				if (mark) {
+				if (mark && mark.tag !== '') {
 					html.push(this.renderOpeningTag(mark.tag))
 				}
 			})
@@ -309,7 +309,7 @@ class RichTextResolver {
 				.forEach((m) => {
 					const mark = this.getMatchingMark(m)
 
-					if (mark) {
+					if (mark && mark.tag !== '') {
 						html.push(this.renderClosingTag(mark.tag))
 					}
 				})

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -195,6 +195,10 @@ const anchor: MarkSchema = (node: ISbNode) => {
 }
 
 const highlight: MarkSchema = (node: ISbNode) => {
+	if (!node.attrs?.color) return {
+		tag: '',
+	}
+
 	const attrs = {
 		['style']: `background-color:${node.attrs.color};`,
 	}
@@ -209,6 +213,10 @@ const highlight: MarkSchema = (node: ISbNode) => {
 }
 
 const textStyle: MarkSchema = (node: ISbNode) => {
+	if (!node.attrs?.color) return {
+		tag: '',
+	}
+
 	const attrs = {
 		['style']: `color:${node.attrs.color}`,
 	}

--- a/tests/constants/richTextResolver.js
+++ b/tests/constants/richTextResolver.js
@@ -502,3 +502,133 @@ export const TEXT_WITH_EMOJI_VIA_FALLBACKIMAGE = {
     }
   ]
 }
+
+export const TEXT_WITH_COLORS_MISSING_PARAMETERS = {
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "text": "Text with ",
+          "type": "text"
+        },
+        {
+          "text": "highlight",
+          "type": "text",
+          "marks": [
+            {
+              "type": "highlight",
+              "attrs": {
+                "color": ""
+              }
+            }
+          ]
+        },
+        {
+          "text": " colors. And another text ",
+          "type": "text"
+        },
+        {
+          "text": "with text",
+          "type": "text",
+          "marks": [
+            {
+              "type": "textStyle",
+              "attrs": {
+                "color": null
+              }
+            }
+          ]
+        },
+        {
+          "text": " color.",
+          "type": "text"
+        }
+      ]
+    }
+  ]
+}
+
+export const TEXT_MISSING_PARAMETERS = {
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "text": "Text with ",
+          "type": "text"
+        },
+        {
+          "text": "highlight",
+          "type": "text",
+          "marks": [
+            {
+              "type": "highlight",
+              "attrs": {
+                "color": undefined
+              }
+            }
+          ]
+        },
+        {
+          "text": " colors. And another text ",
+          "type": "text"
+        },
+        {
+          "text": "with text",
+          "type": "text",
+          "marks": [
+            {
+              "type": "textStyle",
+              "attrs": {}
+            }
+          ]
+        },
+        {
+          "text": " color.",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "text": "Text with ",
+          "type": "text"
+        },
+        {
+          "text": "highlight",
+          "type": "text",
+          "marks": [
+            {
+              "type": "highlight",
+              "attrs": {
+                "color": null
+              }
+            }
+          ]
+        },
+        {
+          "text": " colors. And another text ",
+          "type": "text"
+        },
+        {
+          "text": "with text",
+          "type": "text",
+          "marks": [
+            {
+              "type": "textStyle",
+            }
+          ]
+        },
+        {
+          "text": " color.",
+          "type": "text"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/richTextResolver.test.js
+++ b/tests/richTextResolver.test.js
@@ -17,7 +17,9 @@ import {
 	HIGLIGHT_COLOR_DATA,
 	BOLD_TEXT,
 	TEXT_WITH_EMOJI,
-	TEXT_WITH_EMOJI_VIA_FALLBACKIMAGE
+	TEXT_WITH_EMOJI_VIA_FALLBACKIMAGE,
+	TEXT_WITH_COLORS_MISSING_PARAMETERS,
+	TEXT_MISSING_PARAMETERS,
 } from './constants/richTextResolver'
 
 const TOKEN = 'w0yFvs04aKF2rpz6F8OfIQtt'
@@ -518,6 +520,22 @@ test('should render a anchor in the middle of a text', () => {
 test('should render a text with bold', () => {
 	const result = resolver.render(BOLD_TEXT)
 	const expected = '<b>Lorem Ipsum</b>'
+
+	expect(result).toBe(expected)
+})
+
+test('should not render atributes when they are null or empty string', () => {
+	const result = resolver.render(TEXT_WITH_COLORS_MISSING_PARAMETERS)
+
+	const expected = '<p>Text with highlight colors. And another text with text color.</p>'
+
+	expect(result).toBe(expected)
+})
+
+test('should not render atributes when they are undefined or broken', () => {
+	const result = resolver.render(TEXT_MISSING_PARAMETERS)
+
+	const expected = '<p>Text with highlight colors. And another text with text color.</p><p>Text with highlight colors. And another text with text color.</p>'
 
 	expect(result).toBe(expected)
 })


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix

## How to test this PR

[The idea is to fix this issue](https://github.com/storyblok/storyblok-js-client/issues/543)

## What is the new behavior?

- Now if the color attributes are not passed correctly, the renderer will not create the span tags.

## Other information
