### PR TITLE
feat: add isRichTextEmpty util

### DIFF
--- a/src/richTextResolver.ts
+++ b/src/richTextResolver.ts
@@ -79,14 +79,18 @@ class RichTextResolver {
 		this.marks[key] = schema
 	}
 
+	public static isRichTextEmpty(data?: ISbRichtext) {
+		return !data || (data?.content?.[0].type !== "blok" && !data?.content?.[0].content);
+	}
+
 	public render(
 		data?: ISbRichtext,
 		options: RenderOptions = { optimizeImages: false }
 	) {
-		if (data && data.content && Array.isArray(data.content)) {
+		if (!RichTextResolver.isRichTextEmpty(data)) {
 			let html = ''
 
-			data.content.forEach((node) => {
+			data?.content?.forEach((node) => {
 				html += this.renderNode(node)
 			})
 
@@ -97,32 +101,6 @@ class RichTextResolver {
 			return html
 		}
 
-		console.warn(
-			`The render method must receive an Object with a "content" field.
-			The "content" field must be an array of nodes as the type ISbRichtext.
-			ISbRichtext:
-				content?: ISbRichtext[]
-				marks?: ISbRichtext[]
-				attrs?: any
-				text?: string
-				type: string
-				
-				Example:
-				{
-					content: [
-						{
-							content: [
-								{
-									text: 'Hello World',
-									type: 'text'
-								}
-							],
-							type: 'paragraph'
-						}
-					],
-					type: 'doc'
-				}`
-		)
 		return ''
 	}
 


### PR DESCRIPTION
## Pull request type

Jira Link: [WEB-419](https://storyblok.atlassian.net/jira/software/c/projects/WEB/boards/18?view=detail&selectedIssue=WEB-419)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

I have looked at the playground folder and it looks like maybe testing is still being added? Or maybe I missed it? Is there a standardized way of adding tests?

## What is the new behavior?

Currently, an empty `richtext` field returns the following JSON:
```
"richtext": 
     {
       "type": "doc",
        "content": 
           [
               {
                  "type": "paragraph"
               }
            ]
     },
``` 

This means that:

1. Accessing the `richtext` data simply through `blok.richtext` will always return true, even if the field is empty. Conditional logic based on accessing `richtext` like this won't work. 
2. The check in the current implementation in the renderer (line 86), outlined below, will pass for all `richtext` data given to it, since a `richtext` field will always have a `content` field that is an array, even if the field is empty. In which case, instead of users receiving the console warning about empty or undefined `richtext` fields, a set of empty `<p></p>` tags gets rendered. 

```javascript
if (data && data.content && Array.isArray(data.content))
``` 

My proposed approach to handling this scenario is to 

- Add a static method for truly checking whether the `richtext` field is empty that can be used independently
    - This enables users to create conditional logic based on the state of the `richtext` field outside of the renderer
- Replacing the current check inside the renderer with the new method
- Remove console warning since it is redundant - empty `richtext` fields will render nothing instead of empty `<p></p>` tags, there's nothing to warn users about. If they want to explicitly be informed of the state of the field, they can use the newly added method. 

I am not too sure whether the last step is the best approach. Are there cases when users would **want** to be warned that the `richtext` field currently being handled is empty? Personally, I find the experience of not having to worry about the state of the `richtext` at all and letting the renderer resolve it very appealing, and I wouldn't want to be forced to use `isRichTextEmpty` in conjunction with the renderer every time I am parsing `richtext` in order to avoid that warning. But there may have been other perspectives and use cases that I've missed, so I'm more than happy to reconsider and change any of the approaches listed above. 😄 
I'm also not sure if the best place for the utility to live is as a static method directly on the class like this, perhaps it's better to have it separate somewhere else? Happy to listen to feedback on this as well.


## Other information
I have made the `data` parameter for the `isRichTextEmpty` method optional so that TS doesn't yell at you if you're using the [storyblok-generate-ts](https://www.npmjs.com/package/storyblok-generate-ts) package to generate types for you, a lot of which end up as conditional types if the fields aren't set as mandatory in the CMS. If this is not desired behavior, I'm happy to update :) 

[WEB-419]: https://storyblok.atlassian.net/browse/WEB-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ