### PR TITLE
feat: add endpoint to config as an alias

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,9 @@ class Storyblok {
 	 * @param config ISbConfig interface
 	 * @param endpoint string, optional
 	 */
-	public constructor(config: ISbConfig, endpoint?: string) {
+	public constructor(config: ISbConfig, pEndpoint?: string) {
+		let endpoint = config.endpoint || pEndpoint
+
 		if (!endpoint) {
 			const getRegion = new SbHelpers().getRegionURL
 			const protocol = config.https === false ? 'http' : 'https'
@@ -585,7 +587,7 @@ class Storyblok {
 						retries = retries ? retries + 1 : 0
 
 						if (retries < this.maxRetries) {
-							console.log(`Hit rate limit. Retrying in ${retries} seconds.`);
+							console.log(`Hit rate limit. Retrying in ${retries} seconds.`)
 							await this.helpers.delay(1000 * retries)
 							return this.cacheResponse(url, params, retries)
 								.then(resolve)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -177,6 +177,7 @@ export interface ISbConfig {
 	rateLimit?: number
 	componentResolver?: (component: string, data: any) => void
 	richTextSchema?: ISbSchema
+	endpoint?: string
 }
 
 export interface ISbResult {
@@ -265,8 +266,8 @@ export interface ISbRichtext {
 }
 
 export interface LinkCustomAttributes {
-	rel?: string,
-	title?: string,
+	rel?: string
+	title?: string
 	[key: string]: any
 }
 


### PR DESCRIPTION


Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- Add a custom `endpoint` to the config and check it's using it as baseURL - `new StoryblokClient({ accessToken: '...', endpoint: 'https://foobar.com' })`
- (Retro-compatibility) Same but using it as second parameter - `new StoryblokClient({ ... }, endpoint: 'https://foobar.com')`



## What is the new behavior?

Just an alias to be able to pass `endpoint` as a config param, while keeping it available as well as 2nd param of constructor for retro-compatibility.

This will **enable all Frontend SDKs to use this option with no single change in the SDK ecosystem**.

```js
// **** This 2 ways are equivalent ****

// As config param
new StoryblokClient({ accessToken: '...', endpoint: 'https://foobar.com' })

// As 2nd parameter
new StoryblokClient({ accessToken: '...' }, endpoint: 'https://foobar.com')
```
