### PR TITLE
fix: add exports TS types files in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,18 @@
 	"exports": {
 		".": {
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.umd.js"
+			"require": "./dist/index.umd.js",
+			"types": "./dist/types/entry.esm.d.ts"
 		},
 		"./richTextResolver": {
 			"import": "./dist/richTextResolver.mjs",
-			"require": "./dist/richTextResolver.umd.js"
+			"require": "./dist/richTextResolver.umd.js",
+			"types": "./dist/types/richTextResolver.d.ts"
 		},
 		"./schema": {
 			"import": "./dist/schema.mjs",
-			"require": "./dist/schema.umd.js"
+			"require": "./dist/schema.umd.js",
+			"types": "./dist/types/schema.d.ts"
 		}
 	},
 	"files": [


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
- Fix

Jira Link: 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
- React or Gatsby SDK side
i.e. Gatsby SDK: `lib/types.ts`, `ISbStoryData` didn't have the correct TS types detected. Suggestions from the text editor were not showing the available values.

1. Find node_modules, go to `@storyblok`
2. Add changes from [https://github.com/storyblok/storyblok-js-client/compare/main...fix/ts-types-export-config](https://github.com/storyblok/storyblok-js-client/compare/main...fix/ts-types-export-config)
3. TS types work correctly

- JS Client side
1. Fetch `fix/ts-types-export-config` branch
4. Pull changes
5. Build if necessary 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- TS type exports pointed to the correct files (See at the root [package.json](https://github.com/storyblok/storyblok-js-client/compare/main...fix/ts-types-export-config))
- TS type suggestions from the text editor detects correct available values

## Other information
If you'll need further information, @alexjoverm can explain you in the internal SDK sync call.
