### PR TITLE
feat(int-976): Adding default header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 	<a  href="https://www.storyblok.com?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-js-client"  align="center">
 		<img  src="https://a.storyblok.com/f/88751/1776x360/4d075611c6/sb-js-sdk.png"  alt="Storyblok Logo">
 	</a>
-	<h1 align="center">Universal JavaScript SDK for Storyblok's API</h1>
+	<h1 align="center">Universal JavaScript Client for Storyblok's API</h1>
 	<p align="center">This client is a thin wrapper for the <a href="http://www.storyblok.com?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-js-client" target="_blank">Storyblok</a> API's to use in Node.js and the browser.</p>
 </div>
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,3 +9,11 @@ type ObjectValues<T> = T[keyof T]
 type Method = ObjectValues<typeof METHOD>
 
 export default Method
+
+export const STORYBLOK_AGENT = 'SB_Agent'
+
+export const STORYBLOK_JS_CLIENT_AGENT = {
+	defaultAgentName: 'SB-JS-CLIENT',
+	defaultAgentVersion: 'SB-Agent-Version',
+	packageVersion: process.env.npm_package_version || '5.0.0'
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ type Method = ObjectValues<typeof METHOD>
 
 export default Method
 
-export const STORYBLOK_AGENT = 'SB_Agent'
+export const STORYBLOK_AGENT = 'SB-Agent'
 
 export const STORYBLOK_JS_CLIENT_AGENT = {
 	defaultAgentName: 'SB-JS-CLIENT',

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,9 @@ class Storyblok {
 			for (const header in config.headers) {
 				headers.set(header, config.headers[header])
 			}
-		} else if (!headers.has(STORYBLOK_AGENT)) {
+		}
+		
+		if (!headers.has(STORYBLOK_AGENT)) {
 			headers.set(STORYBLOK_AGENT, STORYBLOK_JS_CLIENT_AGENT.defaultAgentName)
 			headers.set( STORYBLOK_JS_CLIENT_AGENT.defaultAgentVersion,  STORYBLOK_JS_CLIENT_AGENT.packageVersion)
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import throttledQueue from './throttlePromise'
 import RichTextResolver from './richTextResolver'
 import { SbHelpers } from './sbHelpers'
 import SbFetch from './sbFetch'
+import { STORYBLOK_AGENT, STORYBLOK_JS_CLIENT_AGENT } from './constants'
 
 import Method from './constants'
 import {
@@ -99,11 +100,14 @@ class Storyblok {
 		headers.set('Content-Type', 'application/json')
 		headers.set('Accept', 'application/json')
 
-		headers.forEach((value, key) => {
-			if (config.headers && config.headers[key]) {
-				headers.set(key, config.headers[key])
+		if (config.headers) {
+			for (const header in config.headers) {
+				headers.set(header, config.headers[header])
 			}
-		})
+		} else if (!headers.has(STORYBLOK_AGENT)) {
+			headers.set(STORYBLOK_AGENT, STORYBLOK_JS_CLIENT_AGENT.defaultAgentName)
+			headers.set( STORYBLOK_JS_CLIENT_AGENT.defaultAgentVersion,  STORYBLOK_JS_CLIENT_AGENT.packageVersion)
+		}
 
 		let rateLimit = 5 // per second for cdn api
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-977](https://storyblok.atlassian.net/browse/INT-977)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Feature

## How to test this PR

Now is possible to pass custom headers, to identify the client and the request in our infrastructure
If no default headers it's not passed, the js-client will add a default header for that.

```js

const Storyblok = new StoryblokClient({
    accessToken: 'NICE_TOKEN',
    cache: { type: 'memory', clear: 'auto' },
    headers: {
        'SB-Agent': "SB-FE" // Default header for the V2 Frontend
        'SB-Agent-Version': "2.0.0" // Default header for the V2 version
    }
})
```

## What is the new behavior?

- It's possible to use custom headers, add in config object
- Now in all request the js-client send the default header to identify the client in the infrastructure.

## Other information


[INT-977]: https://storyblok.atlassian.net/browse/INT-977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ