### PR TITLE
Fix "process is not defined" when using SvelteKit

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,5 +15,5 @@ export const STORYBLOK_AGENT = 'SB-Agent'
 export const STORYBLOK_JS_CLIENT_AGENT = {
 	defaultAgentName: 'SB-JS-CLIENT',
 	defaultAgentVersion: 'SB-Agent-Version',
-	packageVersion: process.env.npm_package_version || '5.0.0'
+	packageVersion: (typeof process !== 'undefined' && process.env.npm_package_version) || '5.0.0'
 }


### PR DESCRIPTION
## Pull request type

- [ ] Bugfix

## How to test this PR

When using `storyblok-js-client` in a Svelte `+page.ts` file an error is thrown in browser during hydration with the message _`process is not defined`_. This is due to Svelte not generating a `process.env` object in the browser bundle in favour of a different env system.

## What is the new behavior?

- The new code checks for the existence of `process`
