### PR TITLE
feature: support for link as resolve_links value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -494,7 +494,7 @@ class Storyblok {
 
 		if (
 			params.resolve_links &&
-			['1', 'story', 'url'].indexOf(params.resolve_links) > -1 &&
+			['1', 'story', 'url', 'link'].indexOf(params.resolve_links) > -1 &&
 			(responseData.links?.length || responseData.link_uuids?.length)
 		) {
 			await this.resolveLinks(responseData, params, resolveId)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,7 +10,7 @@ export interface ISbStoriesParams {
 	excluding_ids?: string
 	excluding_fields?: string
 	version?: 'draft' | 'published'
-	resolve_links?: 'url' | 'story' | '0' | '1' | 'link'
+	resolve_links?: 'link' | 'url' | 'story' | '0' | '1' | 'link'
 	resolve_relations?: string | string[]
 	resolve_assets?: number
 	cv?: number
@@ -42,7 +42,7 @@ export interface ISbStoryParams {
 	token?: string
 	find_by?: 'uuid'
 	version?: 'draft' | 'published'
-	resolve_links?: 'url' | 'story' | '0' | '1'
+	resolve_links?: 'link' | 'url' | 'story' | '0' | '1'
 	resolve_relations?: string | string[]
 	cv?: number
 	from_release?: string


### PR DESCRIPTION
This PR adds support for the `link` value of the `resolve_links` parameter. Resolved links will be injected inside the link objects like it happens when `resolve_links` is set to `url` or `story`. This new value was added a few months ago but it was not supported yet by the JS Client.

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Retrieve a story with a link field and set the `resolve_links` parameter in the request to `link`. You should see the `story` object injected inside the link object like it happens with `url` or `story`.

## What is the new behavior?

The `link` value is now supported for injected resolved links in link objects.

-
-
-

## Other information
