### PR TITLE
fix(int-1038): Add “real_path” property to the interface for Links API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Error handling from fetch has changed. Exceptions will be thrown as an object wi
 }
 ```
 
-You don't need to parse the response.
+You don't need to parse the error from the client's side.
 
 ### BREAKING CHANGES - FROM VERSION 5
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [6.0.0] - 2022-08-15
+## [6.0.0] - 2023-08-15
 
 ### Changed
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -281,6 +281,7 @@ export interface ISbLink {
 	position?: number
 	uuid?: string
 	is_startpage?: boolean
+	real_path?: string
 }
 
 export interface ISbLinks {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-1038](https://storyblok.atlassian.net/browse/INT-1038)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

## How to test this PR

Import the interfaces and check if the new parameter will works as expected.

## What is the new behavior?
- Now the `ISbLink` and `ISbLinks` interfaces has the `real_path` parameter


## Other information


[INT-1038]: https://storyblok.atlassian.net/browse/INT-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ