### PR TITLE
Update strike mark deprecated tag

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -108,7 +108,7 @@ const bold: MarkSchema = () => {
 }
 const strike: MarkSchema = () => {
 	return {
-		tag: 'strike',
+		tag: 's',
 	}
 }
 const underline: MarkSchema = () => {

--- a/tests/richTextResolver.test.js
+++ b/tests/richTextResolver.test.js
@@ -358,7 +358,7 @@ test('link to generate a tag with achor', () => {
 test('Complex and immutability test', () => {
 	const result = resolver.render(LONG_TEXT_FOR_IMMUTABILITY_TEST)
 	const expected =
-		'<p><b>Lorem</b> ipsum, <strike>dolor</strike> sit amet <u>consectetur</u> adipisicing elit. <code>Eos architecto</code> asperiores temporibus <a href="/test/our-service#anchor-text" uuid="931e04b7-f701-4fe4-8ec0-78be0bee8809" target="_blank">suscipit harum </a>ut, fugit, cumque <a href="asdfsdfasf" target="_blank">molestiae </a>ratione non adipisci, <i>facilis</i> inventore optio dolores. Rem, perspiciatis <a href="/home" uuid="fc6a453f-9aa6-4a00-a22d-49c5878f7983" target="_self">deserunt!</a> Esse, maiores!</p>'
+		'<p><b>Lorem</b> ipsum, <s>dolor</s> sit amet <u>consectetur</u> adipisicing elit. <code>Eos architecto</code> asperiores temporibus <a href="/test/our-service#anchor-text" uuid="931e04b7-f701-4fe4-8ec0-78be0bee8809" target="_blank">suscipit harum </a>ut, fugit, cumque <a href="asdfsdfasf" target="_blank">molestiae </a>ratione non adipisci, <i>facilis</i> inventore optio dolores. Rem, perspiciatis <a href="/home" uuid="fc6a453f-9aa6-4a00-a22d-49c5878f7983" target="_self">deserunt!</a> Esse, maiores!</p>'
 
 	expect(result).toBe(expected)
 })


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
strike tag is deprecated (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strike).
Change it to s tag (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- It should return an "s" tag instead of the "strike" tag

## Other information
