### PR TITLE
fix: update the retry function to check the response status correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -592,18 +592,6 @@ class Storyblok {
 		return new Promise(async (resolve, reject) => {
 			try {
 				const res = await this.throttle('get', url, params)
-				if (res.status === 429) {
-					retries = retries ? retries + 1 : 0
-
-					if (retries < this.maxRetries) {
-						console.log(`Hit rate limit. Retrying in ${retries} seconds.`)
-						await this.helpers.delay(1000 * retries)
-						return this.cacheResponse(url, params, retries)
-							.then(resolve)
-							.catch(reject)
-					}
-				}
-				
 				if (res.status !== 200) {
 					return reject(res)
 				}
@@ -640,6 +628,17 @@ class Storyblok {
 
 				return resolve(response)
 			} catch (error: Error | any) {
+				if (error.response && error.status === 429) {
+					retries = retries ? retries + 1 : 0
+
+					if (retries < this.maxRetries) {
+						console.log(`Hit rate limit. Retrying in ${retries} seconds.`)
+						await this.helpers.delay(1000 * retries)
+						return this.cacheResponse(url, params, retries)
+							.then(resolve)
+							.catch(reject)
+					}
+				}
 				reject(error)
 			}
 		})


### PR DESCRIPTION
This PR fixes the function that retries requests when a rate limit is hit. This bug was already present in the past and somebody tried to fix it in the #732 but that didn't seem the solution.

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

You need to test this both in Node and client-side.

*Node.js*
In the `playground/index-node.js` put the content below and then run `node playground/index-node`.

```
const Client = require('../')

const client = new Client({
  accessToken: "GWArsF7QLxYmJjPDQ4P5Awtt",
  rateLimit: 70,
  maxRetries: 30
});

const getLinks = async () => {
  console.time("APIrequests");
  const stories = 5000
  const perPage = 25
  const pages = Math.ceil(stories / perPage)

  try {
    const requests = []
    for (let index = 0; index < pages; index++) {
      requests.push(client.get("cdn/stories", {per_page: perPage, page: index}))
    }
    const res = (await Promise.all(requests))
    console.timeEnd("APIrequests");
} catch(err) {
  console.log(err)
}
};

getLinks();
```

*Client-side*
In the `playground/main.ts` add the code below, then run in the console `npm run demo` and in your browser refresh the page of the demo until you see the retry message in the console.

```
import StoryblokClient from '../'

const client = new StoryblokClient({
  accessToken: "GWArsF7QLxYmJjPDQ4P5Awtt",
  rateLimit: 70,
  maxRetries: 30
});

const getLinks = async () => {
  console.time("APIrequests");
  const stories = 5000
  const perPage = 25
  const pages = Math.ceil(stories / perPage)

  try {
    const requests = []
    for (let index = 0; index < pages; index++) {
      requests.push(client.get("cdn/stories", {per_page: perPage, page: index}))
    }
    const res = (await Promise.all(requests))
    console.timeEnd("APIrequests");
} catch(err) {
  console.log(err)
}
};

getLinks();
```

## What is the new behavior?

Once a rate limit is hit the retry mechanism is executed and the console will show the message "Hit rate limit. Retrying in X seconds."

## Other information
