### PR TITLE
fix: update typings to match api response

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -80,34 +80,34 @@ export interface ISbStoryData<
 	Content = ISbComponentType<string> & { [index: string]: any },
 > extends ISbMultipleStoriesData {
 	alternates: ISbAlternateObject[]
-	breadcrumbs: ISbLinkURLObject[]
+	breadcrumbs?: ISbLinkURLObject[]
 	content: Content
 	created_at: string
 	default_full_slug?: string
-	default_root: string
-	disble_fe_editor: boolean
+	default_root?: string
+	disble_fe_editor?: boolean
 	first_published_at?: string
 	full_slug: string
 	group_id: string
 	id: number
-	imported_at: string
-	is_folder: boolean
+	imported_at?: string
+	is_folder?: boolean
 	is_startpage?: boolean
 	lang: string
-	last_author: {
+	last_author?: {
 		id: number
 		userid: string
 	}
 	meta_data: any
 	name: string
-	parent: ISbStoryData
+	parent?: ISbStoryData
 	parent_id: number
 	path?: string
-	pinned: '1' | boolean
+	pinned?: '1' | boolean
 	position: number
-	published: boolean
+	published?: boolean
 	published_at: string | null
-	release_id: number
+	release_id?: number
 	slug: string
 	sort_by_date: string | null
 	tag_list: string[]
@@ -116,8 +116,8 @@ export interface ISbStoryData<
 		name: string | null
 		lang: ISbStoryData['lang']
 	}[]
-	unpublished_changes: boolean
-	updated_at: string
+	unpublished_changes?: boolean
+	updated_at?: string
 	uuid: string
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request Type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

Request a random story and log the result, compare what you get with what the typing says you should've gotten.
Example:
![Screenshot 2024-01-25 at 19 53 06](https://github.com/storyblok/storyblok-js-client/assets/10922421/10f7da09-982b-457d-821c-caa17c823ab5)


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

This fixes the typings that were broken in #697 and makes sure that the typing actually matches the API response.
All of these are on the `ISbStoryData` interface.
Many are fields have to be optional, as they are not always returned. I've marked them as optional as well, because [you specifically requested that from the last fix](https://github.com/storyblok/storyblok-js-client/pull/738#discussion_r1450562270), although the API does return `null` instead in many cases, so this will still be slightly incorrect typing.
One of the changes stands out, and that is marking `parent` as optional. Anything else is impossible over JSON, as a recursive structure needs an anchor; the root element does not have a parent.

## Other information
