### PR TITLE
fix: Change UMD export spelling of RichTextSchema to RichtextSchema

### DIFF
--- a/src/entry.umd.ts
+++ b/src/entry.umd.ts
@@ -1,14 +1,14 @@
 import Client from './index'
 import RichtextResolver from './richTextResolver'
 import SbFetch from './sbFetch'
-import RichTextSchema from './schema'
+import RichtextSchema from './schema'
 import * as sbHelpers from './sbHelpers'
 
 const extend = (to: Record<any, any>, _from: Record<any, any>) => {
 	for (const key in _from) to[key] = _from[key]
 }
 
-extend(Client, { RichtextResolver, SbFetch, RichTextSchema })
+extend(Client, { RichtextResolver, SbFetch, RichtextSchema })
 extend(Client, sbHelpers)
 
 // Single default export object for UMD friendly bundle


### PR DESCRIPTION
fixes: #777 

The spelling of `RichtextSchema` differed between the ESM export and the UMD export.
To maintain consistency I changed the UMD export from `RichTextSchema` to `RichtextSchema`.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- UMd export now matches ESM export

## Other information

This should probably be a major version, since it may break existing code.

BREAKING CHANGE: The spelling of RichTextSchema has been changed to RichtextSchema in UMD exports to match ESM export. This may require updates in code where this export is used.