### PR TITLE
fix: update typing for not-yet published stories

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -88,10 +88,10 @@ export interface ISbStoryData<
   breadcrumbs?: ISbLinkURLObject[]
   content: Content
   created_at: string
-  default_full_slug?: string
+  default_full_slug?: string | null
   default_root?: string
   disble_fe_editor?: boolean
-  first_published_at?: string
+  first_published_at?: string | null
   full_slug: string
   group_id: string
   id: number
@@ -106,13 +106,13 @@ export interface ISbStoryData<
   meta_data: any
   name: string
   parent?: ISbStoryData
-  parent_id: number
+  parent_id: number | null
   path?: string
   pinned?: '1' | boolean
   position: number
   published?: boolean
   published_at: string | null
-  release_id?: number
+  release_id?: number | null
   slug: string
   sort_by_date: string | null
   tag_list: string[]
@@ -120,7 +120,7 @@ export interface ISbStoryData<
     path: string
     name: string | null
     lang: ISbStoryData['lang']
-  }[]
+  }[] | null
   unpublished_changes?: boolean
   updated_at?: string
   uuid: string


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
Create a new story in the root directory (and only save it, don't publish it) and access its draft version via the API. The response should contain the following `null` values that are not yet reflected in the typing:

```json
{
   "story":{
      ...
      "parent_id": null,
      ...
      "first_published_at":null,
      "release_id":null,
      ...
      "default_full_slug":null,
      "translated_slugs":null
   },
   ...
}
```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

fields can now be `null` according to the typing

## Other information

I've missed those fields in #763 as I only checked for published stories, this should now cover all story states.

It may be a good idea to split between Published/Non-Published state but that's probably something for usages of the library as it would be a big change.