### PR TITLE
refactor: use region-helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "storyblok-js-client",
 			"version": "5.0.0",
 			"license": "MIT",
+			"dependencies": {
+				"@storyblok/region-helper": "^0.1.0"
+			},
 			"devDependencies": {
 				"@commitlint/cli": "^18.4.3",
 				"@commitlint/config-conventional": "^18.4.3",
@@ -1130,6 +1133,11 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
 			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"dev": true
+		},
+		"node_modules/@storyblok/region-helper": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@storyblok/region-helper/-/region-helper-0.1.0.tgz",
+			"integrity": "sha512-psDn8OrU9y1Y7qWXbUCeNQ1U+8XyumerE5MBTfN+06L/lRlR9DJ4BRWOlx/cjKF6RXd5CnUBjcg1BNM3IupIkA=="
 		},
 		"node_modules/@tsconfig/recommended": {
 			"version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "5.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@storyblok/region-helper": "^0.1.0"
+				"@storyblok/region-helper": "^0.2.0"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "^18.4.3",
@@ -1135,9 +1135,9 @@
 			"dev": true
 		},
 		"node_modules/@storyblok/region-helper": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@storyblok/region-helper/-/region-helper-0.1.0.tgz",
-			"integrity": "sha512-psDn8OrU9y1Y7qWXbUCeNQ1U+8XyumerE5MBTfN+06L/lRlR9DJ4BRWOlx/cjKF6RXd5CnUBjcg1BNM3IupIkA=="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@storyblok/region-helper/-/region-helper-0.2.0.tgz",
+			"integrity": "sha512-LOSFgAiHTmxuBsrjkpTwCk5ZGKmMVmxfmxv8Mi305RtT/o7JOZrjZXnP7kLbLu7m0F18wVVGFmS6XJqbFhBfcA=="
 		},
 		"node_modules/@tsconfig/recommended": {
 			"version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "5.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@storyblok/region-helper": "^0.2.0"
+				"@storyblok/region-helper": "^1.0.0"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "^18.4.3",
@@ -1135,9 +1135,9 @@
 			"dev": true
 		},
 		"node_modules/@storyblok/region-helper": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@storyblok/region-helper/-/region-helper-0.2.0.tgz",
-			"integrity": "sha512-LOSFgAiHTmxuBsrjkpTwCk5ZGKmMVmxfmxv8Mi305RtT/o7JOZrjZXnP7kLbLu7m0F18wVVGFmS6XJqbFhBfcA=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@storyblok/region-helper/-/region-helper-1.0.0.tgz",
+			"integrity": "sha512-02B4J3XzD6CLK8DAQbK63fSar8oGYqBJxdx+7Ya0C3uJwMU5DzOMix6ShtUo1iDSd9rOl8aA5wDoCC0wh0YHMw=="
 		},
 		"node_modules/@tsconfig/recommended": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,6 @@
 		"useTabs": true
 	},
 	"dependencies": {
-		"@storyblok/region-helper": "^0.2.0"
+		"@storyblok/region-helper": "^1.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,6 @@
 		"useTabs": true
 	},
 	"dependencies": {
-		"@storyblok/region-helper": "^0.1.0"
+		"@storyblok/region-helper": "^0.2.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -120,5 +120,8 @@
 		"tabWidth": 2,
 		"trailingComma": "es5",
 		"useTabs": true
+	},
+	"dependencies": {
+		"@storyblok/region-helper": "^0.1.0"
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import RichTextResolver from './richTextResolver'
 import { SbHelpers } from './sbHelpers'
 import SbFetch from './sbFetch'
 import { STORYBLOK_AGENT, STORYBLOK_JS_CLIENT_AGENT } from './constants'
+import { getRegionUrl, type Region } from '@storyblok/region-helper'
 
 import Method from './constants'
 import {
@@ -87,13 +88,12 @@ class Storyblok {
 		let endpoint = config.endpoint || pEndpoint
 
 		if (!endpoint) {
-			const getRegion = new SbHelpers().getRegionURL
 			const protocol = config.https === false ? 'http' : 'https'
 
 			if (!config.oauthToken) {
-				endpoint = `${protocol}://${getRegion(config.region)}/${'v2' as Version}`
+				endpoint = `${protocol}://${getRegionUrl(config.region as Region)}/${'v2' as Version}`
 			} else {
-				endpoint = `${protocol}://${getRegion(config.region)}/${'v1' as Version}`
+				endpoint = `${protocol}://${getRegionUrl(config.region as Region)}/${'v1' as Version}`
 			}
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import RichTextResolver from './richTextResolver'
 import { SbHelpers } from './sbHelpers'
 import SbFetch from './sbFetch'
 import { STORYBLOK_AGENT, STORYBLOK_JS_CLIENT_AGENT } from './constants'
-import { getRegionUrl, type Region } from '@storyblok/region-helper'
+import { getRegionBaseUrl, type Region } from '@storyblok/region-helper'
 
 import Method from './constants'
 import {
@@ -91,9 +91,9 @@ class Storyblok {
 			const protocol = config.https === false ? 'http' : 'https'
 
 			if (!config.oauthToken) {
-				endpoint = `${protocol}://${getRegionUrl(config.region as Region)}/${'v2' as Version}`
+				endpoint = `${getRegionBaseUrl(config.region as Region,protocol)}/${'v2' as Version}`
 			} else {
-				endpoint = `${protocol}://${getRegionUrl(config.region as Region)}/${'v1' as Version}`
+				endpoint = `${getRegionBaseUrl(config.region as Region,protocol)}/${'v1' as Version}`
 			}
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,9 +91,9 @@ class Storyblok {
 			const protocol = config.https === false ? 'http' : 'https'
 
 			if (!config.oauthToken) {
-				endpoint = `${getRegionBaseUrl(config.region as Region,protocol)}/${'v2' as Version}`
+				endpoint = `${getRegionBaseUrl(config.region as Region, protocol)}/${'v2' as Version}`
 			} else {
-				endpoint = `${getRegionBaseUrl(config.region as Region,protocol)}/${'v1' as Version}`
+				endpoint = `${getRegionBaseUrl(config.region as Region, protocol)}/${'v1' as Version}`
 			}
 		}
 

--- a/src/sbHelpers.ts
+++ b/src/sbHelpers.ts
@@ -78,32 +78,6 @@ export class SbHelpers {
 	}
 
 	/**
-	 * @method getRegionURL
-	 * @param  {String} regionCode region code, could be eu, us, cn, ap or ca
-	 * @return {String} The base URL of the region
-	 */
-	public getRegionURL(regionCode?: string): string {
-		const EU_API_URL = 'api.storyblok.com'
-		const US_API_URL = 'api-us.storyblok.com'
-		const CN_API_URL = 'app.storyblokchina.cn'
-		const AP_API_URL = 'api-ap.storyblok.com'
-		const CA_API_URL = 'api-ca.storyblok.com'
-
-		switch (regionCode) {
-			case 'us':
-				return US_API_URL
-			case 'cn':
-				return CN_API_URL
-			case 'ap':
-				return AP_API_URL
-			case 'ca':
-				return CA_API_URL
-			default:
-				return EU_API_URL
-		}
-	}
-
-	/**
 	 * @method escapeHTML
 	 * @param  {String} string text to be parsed
 	 * @return {String} Text parsed

--- a/tests/units/helpers.test.js
+++ b/tests/units/helpers.test.js
@@ -91,39 +91,3 @@ describe('flatMap function', () => {
 		expect(helpers.flatMap([0, 2], (v) => [v, v + 1])).toEqual([0, 1, 2, 3])
 	})
 })
-
-describe('getRegionURL function', () => {
-	const EU_API_URL = 'api.storyblok.com'
-	const US_API_URL = 'api-us.storyblok.com'
-	const CN_API_URL = 'app.storyblokchina.cn'
-	const AP_API_URL = 'api-ap.storyblok.com'
-	const CA_API_URL = 'api-ca.storyblok.com'
-
-	test('should return the europe url when pass a empty string', () => {
-		expect(helpers.getRegionURL('')).toEqual(EU_API_URL)
-	})
-
-	test('should return the europe url when pass non supported region code', () => {
-		expect(helpers.getRegionURL('nn')).toEqual(EU_API_URL)
-	})
-
-	test('should return the europe url when pass eu string', () => {
-		expect(helpers.getRegionURL('eu')).toEqual(EU_API_URL)
-	})
-
-	test('should return the united states url when pass us string', () => {
-		expect(helpers.getRegionURL('us')).toEqual(US_API_URL)
-	})
-
-	test('should return the china url when pass cn string', () => {
-		expect(helpers.getRegionURL('cn')).toEqual(CN_API_URL)
-	})
-
-	test('should return the australia url when pass ap string', () => {
-		expect(helpers.getRegionURL('ap')).toEqual(AP_API_URL)
-	})
-
-	test('should return the canada url when pass ca string', () => {
-		expect(helpers.getRegionURL('ca')).toEqual(CA_API_URL)
-	})
-})


### PR DESCRIPTION
## Pull request type

Jira Link: [EXT-2185](https://storyblok.atlassian.net/browse/EXT-2122)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Nothing changes. It should pass all the existing tests.

## What is the new behavior?

This PR includes the new `@storyblok/region-helper` library to replace the existing region-related code in this repository. The purpose is to centralize the logic into a single library, and reuse it everywhere (to ease the situation where we add new regions).

You can refer to the internal `#product-regions-configuration` channel or reach out to me for more information.

Basically [the library's code](https://github.com/storyblok/region-helper) is copied from this repository :)

Also, I've ran `npm run build` locally, and confirmed that the `region-helper` was correctly bundled into the final output.

[EXT-2185]: https://storyblok.atlassian.net/browse/EXT-2185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ