### PR TITLE
fix: getStories and getStory fetchOptions Not Being Applied

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -301,10 +301,9 @@ class Storyblok {
 		params: ISbStoriesParams,
 		fetchOptions?: ISbCustomFetch
 	): Promise<ISbStories> {
-		this.client.setFetchOptions(fetchOptions)
 		this._addResolveLevel(params)
 
-		return this.get('cdn/stories', params)
+		return this.get('cdn/stories', params, fetchOptions)
 	}
 
 	public getStory(
@@ -312,10 +311,9 @@ class Storyblok {
 		params: ISbStoryParams,
 		fetchOptions?: ISbCustomFetch
 	): Promise<ISbStory> {
-		this.client.setFetchOptions(fetchOptions)
 		this._addResolveLevel(params)
 
-		return this.get(`cdn/stories/${slug}`, params)
+		return this.get(`cdn/stories/${slug}`, params, fetchOptions)
 	}
 
 	private getToken(): string {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import { expect, test, describe } from 'vitest'
+import { describe, expect, vi, test, beforeEach } from 'vitest'
 import StoryblokClient, { RichtextResolver } from '../'
 
 let Storyblok = new StoryblokClient({
@@ -102,5 +102,38 @@ describe('Test for cdn/links with simultaneous requests', () => {
 				})
 				.catch()
 		}
+	})
+})
+
+describe('test StoryblokClient fetchOptions', () => {
+	beforeEach(() => {
+		vi.spyOn(global, 'fetch')
+	})
+
+	test('getStory should call fetch with correct cache value', async () => {
+		await Storyblok.getStory(
+			'testcontent-0',
+			{ version: 'draft' },
+			{ cache: 'no-cache' }
+		)
+
+		expect(fetch).toHaveBeenCalled()
+		const fetchCall = fetch.mock.calls[0]
+		const fetchOptions = fetchCall[1]
+
+		expect(fetchOptions.cache).toBe('no-cache')
+	})
+
+	test('getStories should call fetch with correct custom header value', async () => {
+		await Storyblok.getStories(
+			{ version: 'draft' },
+			{ headers: { 'custom-header': 'custom-value' } }
+		)
+
+		expect(fetch).toHaveBeenCalled()
+		const fetchCall = fetch.mock.calls[0]
+		const fetchOptions = fetchCall[1]
+
+		expect(fetchOptions.headers['custom-header']).toBe('custom-value')
 	})
 })


### PR DESCRIPTION
Closes #755 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix

## How to test this PR

Try to pass `fetchOptions` to the `getStory` and `getStories` methods and make sure those options are added to the fetch call.

## What is the new behavior?

When you pass `fetchOptions` to `getStory` or `getStories` the fetchOptions will be applied to the fetch call.

## Other information
I added two tests to the test suite to confirm this is working correctly.
