### PR TITLE
WEB-790 - Export ISbResponseData interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ interface ISbFlatMapped {
 	data: any
 }
 
-interface ISbResponseData {
+export interface ISbResponseData {
 	link_uuids: string[]
 	links: string[]
 	rel_uuids: string[]


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Run the build command, it should create the lib typedefs in `dist/types/index.d.ts` and the interface `ISbResponseData` should be exported.

## What is the new behavior?

Exporting types from the Storyblok CLI is triggering an error related to `ISbResponseData` not being exported by the `storyblok-js-client` package.
This PR exports the interface `ISbResponseData` so that it shouldn't trigger any error in such cases (tested with @alexjoverm)
