### PR TITLE
fix: clear cacheVersions on flushCache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -680,6 +680,12 @@ class Storyblok {
 		}
 	}
 
+	public clearCacheVersion(): void {
+		if (this.accessToken) {
+			cacheVersions[this.accessToken] = 0
+		}
+	}
+
 	private cacheProvider(): ICacheProvider {
 		switch (this.cache.type) {
 			case 'memory':
@@ -722,6 +728,7 @@ class Storyblok {
 
 	public async flushCache(): Promise<this> {
 		await this.cacheProvider().flush()
+		this.clearCacheVersion();
 		return this
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -728,7 +728,7 @@ class Storyblok {
 
 	public async flushCache(): Promise<this> {
 		await this.cacheProvider().flush()
-		this.clearCacheVersion();
+		this.clearCacheVersion()
 		return this
 	}
 }


### PR DESCRIPTION
This PR fixes the issue number 2 from #806. The issue is intermittent because of a combination of factors, but in some cases it will result in the JS Client serving cached content even after flushing the cache, because the `flushCache` method clears the cache but it doesn't clear the cached `cv` value used for performing requests.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

In order to simulate a case that would be affected by this bug, you can run the following script. To get the accessToken, spaceId, storyId and get added to the space for testing, please DM me. Of course you can setup your own space and script, but with this one it will be quick :-) 

If you run it on the main branch, you will always get the same values for all the 3 requests. With this branch you will get the current value after flushing the cache.

```
import StoryblokClient from "storyblok-js-client";

const oauthToken = "";
const accessToken = ""
const spaceId = "";
const storyId = "";

const Storyblok = new StoryblokClient({
  accessToken,
  cache: {
    clear: "auto",
    type: "memory",
  },
});

const StoryblokMapi = new StoryblokClient({
  oauthToken
});

const updateStory = async () => {
  const hp = await StoryblokMapi.get(`/spaces/${spaceId}/stories/${storyId}`);
  hp.data.story.content.v = parseInt(hp.data.story.content.v) + 1;
  try {
    await StoryblokMapi.put(`/spaces/${spaceId}/stories/${storyId}`, {
      story: hp.data.story,
      publish: 1,
      force_update: 1,
    });
  } catch (e) {
    console.log(e);
  }
};

const getHome = async (cv) => {
  const res = await Storyblok.get("cdn/stories/home", {
    version: "published",
    ...(cv && { cv: Date.now() }),
  });
  console.log(`Test Field value: ${res.data.story.content.v} - Response CV value: ${res.data.cv}`);
};

(async () => {
  try {
    await getHome();
    await getHome();
    await updateStory();
    await Storyblok.flushCache();
    console.log("---");
    await getHome();
  } catch (err) {
    console.log(err);
  }
})();
```

## What is the new behavior?

The `cv` value is set to `0` when the `flushCache` method is executed.

## Other information
