### PR TITLE
Fix(SHAPE-2460):retries loop bug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -623,7 +623,7 @@ class Storyblok {
 					const resolveId = (this.resolveCounter = ++this.resolveCounter % 1000)
 					await this.resolveStories(response.data, params, `${resolveId}`)
 				}
-				
+
 				if (params.version === 'published' && url != '/cdn/spaces/me') {
 					await provider.set(cacheKey, response)
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ class Storyblok {
 		}
 
 		this.maxRetries = config.maxRetries || 10
-		this.retriesDelay = 200
+		this.retriesDelay = 300
 		this.throttle = throttledQueue(this.throttledRequest, rateLimit, 1000)
 		this.accessToken = config.accessToken || ''
 		this.relations = {} as RelationsType

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,8 +138,8 @@ class Storyblok {
 			this.setComponentResolver(config.componentResolver)
 		}
 
-		this.maxRetries = config.maxRetries || 5
-		this.retriesDelay = 100
+		this.maxRetries = config.maxRetries || 10
+		this.retriesDelay = 200
 		this.throttle = throttledQueue(this.throttledRequest, rateLimit, 1000)
 		this.accessToken = config.accessToken || ''
 		this.relations = {} as RelationsType


### PR DESCRIPTION
This PR fixes an issue with a potential loop of infinite retries in case the API returns a 429 response when rate limits are hit. It also updates the retry delay as the current one is too big, and it gets really big as the number of times increases, extending the execution time of the script in case of multiple 429 errors. 

## Pull request type

Jira Link: [SHAPE-2460](https://storyblok.atlassian.net/browse/SHAPE-2460)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Test on the main branch:
- Add this `throw {status: 429, response: "err"}` to [this line](https://github.com/storyblok/storyblok-js-client/blob/b6abea25646e93016d1ee080aae3538f6751d7ab/src/index.ts#L642).
- Perform a get request with the client.
- Check the console. You should see an infinite loop of error messages.

Test on this branch:
- Add this `throw {status: 429, response: "err"}` on line 640 of `src/index.ts`. 
- Perform a get request with the client.
- Check the console. You should see 10 retries, and then the execution of the script will end. 

## What is the new behavior?

The script will retry a specific number of times in case a request fails. The retries will also be quicker. Example:
- First retry delay with this branch: 300ms.
- First retry delay with the main branch: 1000ms.
- Second retry delay with this branch: 300ms.
- Second retry delay with the main branch: 2000ms.
- Third retry delay with this branch: 300ms.
- Third retry delay with the main branch: 3000ms.


[SHAPE-2460]: https://storyblok.atlassian.net/browse/SHAPE-2460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ