### PR TITLE
fix: `_editable` field in ISbComponentType can be `null`

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -75,7 +75,7 @@ export interface ISbDimensions {
 export interface ISbComponentType<T extends string> {
 	_uid?: string
 	component?: T
-	_editable?: string
+	_editable?: string | null
 }
 
 export interface ISbStoryData<


### PR DESCRIPTION
A content type block can come back with `_editable` field as `null`.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Get a story with a content type block and see the `_editable` field.
