### PR TITLE
fix: pass fetchOptions to each request.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,14 +210,15 @@ class Storyblok {
 		url: string,
 		params: ISbStoriesParams,
 		per_page: number,
-		page: number
+		page: number,
+		fetchOptions?: ISbCustomFetch
 	): Promise<ISbResult> {
 		const query = this.factoryParamOptions(
 			url,
 			this.helpers.getOptionsPage(params, per_page, page)
 		)
 
-		return this.cacheResponse(url, query)
+		return this.cacheResponse(url, query, undefined, fetchOptions)
 	}
 
 	public get(
@@ -229,9 +230,7 @@ class Storyblok {
 		const url = `/${slug}`
 		const query = this.factoryParamOptions(url, params)
 
-		this.client.setFetchOptions(fetchOptions)
-
-		return this.cacheResponse(url, query)
+		return this.cacheResponse(url, query, undefined, fetchOptions)
 	}
 
 	public async getAll(
@@ -246,15 +245,13 @@ class Storyblok {
 		const e = entity || urlParts[urlParts.length - 1]
 
 		const firstPage = 1
-		const firstRes = await this.makeRequest(url, params, perPage, firstPage)
+		const firstRes = await this.makeRequest(url, params, perPage, firstPage, fetchOptions)
 		const lastPage = firstRes.total ? Math.ceil(firstRes.total / perPage) : 1
-
-		this.client.setFetchOptions(fetchOptions)
 
 		const restRes: any = await this.helpers.asyncMap(
 			this.helpers.range(firstPage, lastPage),
 			(i: number) => {
-				return this.makeRequest(url, params, perPage, i + 1)
+				return this.makeRequest(url, params, perPage, i + 1, fetchOptions)
 			}
 		)
 
@@ -270,9 +267,7 @@ class Storyblok {
 	): Promise<ISbResponseData> {
 		const url = `/${slug}`
 
-		this.client.setFetchOptions(fetchOptions)
-
-		return Promise.resolve(this.throttle('post', url, params))
+		return Promise.resolve(this.throttle('post', url, params, fetchOptions))
 	}
 
 	public put(
@@ -282,9 +277,7 @@ class Storyblok {
 	): Promise<ISbResponseData> {
 		const url = `/${slug}`
 
-		this.client.setFetchOptions(fetchOptions)
-
-		return Promise.resolve(this.throttle('put', url, params))
+		return Promise.resolve(this.throttle('put', url, params, fetchOptions))
 	}
 
 	public delete(
@@ -294,19 +287,16 @@ class Storyblok {
 	): Promise<ISbResponseData> {
 		const url = `/${slug}`
 
-		this.client.setFetchOptions(fetchOptions)
-
-		return Promise.resolve(this.throttle('delete', url, params))
+		return Promise.resolve(this.throttle('delete', url, params, fetchOptions))
 	}
 
 	public getStories(
 		params: ISbStoriesParams,
 		fetchOptions?: ISbCustomFetch
 	): Promise<ISbStories> {
-		this.client.setFetchOptions(fetchOptions)
 		this._addResolveLevel(params)
 
-		return this.get('cdn/stories', params)
+		return this.get('cdn/stories', params, fetchOptions)
 	}
 
 	public getStory(
@@ -314,10 +304,9 @@ class Storyblok {
 		params: ISbStoryParams,
 		fetchOptions?: ISbCustomFetch
 	): Promise<ISbStory> {
-		this.client.setFetchOptions(fetchOptions)
 		this._addResolveLevel(params)
 
-		return this.get(`cdn/stories/${slug}`, params)
+		return this.get(`cdn/stories/${slug}`, params, fetchOptions)
 	}
 
 	private getToken(): string {
@@ -585,7 +574,8 @@ class Storyblok {
 	private async cacheResponse(
 		url: string,
 		params: ISbStoriesParams,
-		retries?: number
+		retries?: number,
+		fetchOptions?: ISbCustomFetch
 	): Promise<ISbResult> {
 		const cacheKey = this.helpers.stringify({ url: url, params: params })
 		const provider = this.cacheProvider()
@@ -603,7 +593,7 @@ class Storyblok {
 
 		return new Promise(async (resolve, reject) => {
 			try {
-				const res = await this.throttle('get', url, params)
+				const res = await this.throttle('get', url, params, fetchOptions)
 				if (res.status !== 200) {
 					return reject(res)
 				}
@@ -659,8 +649,10 @@ class Storyblok {
 	private throttledRequest(
 		type: Method,
 		url: string,
-		params: ISbStoriesParams
+		params: ISbStoriesParams,
+		fetchOptions?: ISbCustomFetch
 	): Promise<unknown> {
+		this.client.setFetchOptions(fetchOptions)
 		return this.client[type](url, params)
 	}
 


### PR DESCRIPTION
Tentative fix to help understand submitted issue #827. I could iterate on the PRs if needed to go forward.

## Pull request type

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

Each call to get, getAll, put, post, delete, getStory, getStories should get its own values for fetchOptions.

-
-
-

## Other information
