### PR TITLE
feat: add resolve_links_level to pertinent interfaces

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,7 @@ export interface ISbStoriesParams
 	published_at_lt?: string
 	resolve_assets?: number
 	resolve_links?: 'link' | 'url' | 'story' | '0' | '1' | 'link'
+	resolve_links_level?: 1 | 2
 	resolve_relations?: string | string[]
 	search_term?: string
 	size?: string
@@ -47,6 +48,7 @@ export interface ISbStoryParams {
 	find_by?: 'uuid'
 	version?: 'draft' | 'published'
 	resolve_links?: 'link' | 'url' | 'story' | '0' | '1'
+	resolve_links_level?: 1 | 2
 	resolve_relations?: string | string[]
 	cv?: number
 	from_release?: string


### PR DESCRIPTION
Add the [`resolve_links_level` parameter](https://www.storyblok.com/docs/api/content-delivery/v2/stories/retrieve-a-single-story) to the parmaters of the `getStory` and `getStories` methods.

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Try to use the `getStories` or `getStory` method and try adding the `resolve_links_level` parameter. You should be able to see it exposed by the type of the parameters object.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information
