### PR TITLE
feat: make `Storyblok` a "Generic Class" for typed client instances.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   IMemoryType,
   ICacheProvider,
   ISbCustomFetch,
+  ISbContentType,
   ISbResponseData,
 } from './interfaces'
 
@@ -56,7 +57,7 @@ const VERSION = {
 type ObjectValues<T> = T[keyof T]
 type Version = ObjectValues<typeof VERSION>
 
-class Storyblok {
+class Storyblok<Content = ISbContentType> {
   private client: SbFetch
   private maxRetries: number
   private retriesDelay: number
@@ -259,7 +260,7 @@ class Storyblok {
     slug: string,
     params: ISbStoriesParams | ISbContentMangmntAPI,
     fetchOptions?: ISbCustomFetch
-  ): Promise<ISbResponseData> {
+  ): Promise<ISbResponseData<Content>> {
     const url = `/${slug}`
 
     this.client.setFetchOptions(fetchOptions)
@@ -271,7 +272,7 @@ class Storyblok {
     slug: string,
     params: ISbStoriesParams | ISbContentMangmntAPI,
     fetchOptions?: ISbCustomFetch
-  ): Promise<ISbResponseData> {
+  ): Promise<ISbResponseData<Content>> {
     const url = `/${slug}`
 
     this.client.setFetchOptions(fetchOptions)
@@ -283,7 +284,7 @@ class Storyblok {
     slug: string,
     params: ISbStoriesParams | ISbContentMangmntAPI,
     fetchOptions?: ISbCustomFetch
-  ): Promise<ISbResponseData> {
+  ): Promise<ISbResponseData<Content>> {
     const url = `/${slug}`
 
     this.client.setFetchOptions(fetchOptions)
@@ -294,7 +295,7 @@ class Storyblok {
   public getStories(
     params: ISbStoriesParams,
     fetchOptions?: ISbCustomFetch
-  ): Promise<ISbStories> {
+  ): Promise<ISbStories<Content>> {
     this.client.setFetchOptions(fetchOptions)
     this._addResolveLevel(params)
 
@@ -305,7 +306,7 @@ class Storyblok {
     slug: string,
     params: ISbStoryParams,
     fetchOptions?: ISbCustomFetch
-  ): Promise<ISbStory> {
+  ): Promise<ISbStory<Content>> {
     this.client.setFetchOptions(fetchOptions)
     this._addResolveLevel(params)
 
@@ -388,7 +389,7 @@ class Storyblok {
   }
 
   private iterateTree(
-    story: ISbStoryData,
+    story: ISbStoryData<Content>,
     fields: string | Array<string>,
     resolveId: string
   ): void {
@@ -427,11 +428,11 @@ class Storyblok {
   }
 
   private async resolveLinks(
-    responseData: ISbResponseData,
+    responseData: ISbResponseData<Content>,
     params: ISbStoriesParams,
     resolveId: string
   ): Promise<void> {
-    let links: (ISbStoryData | ISbLinkURLObject | string)[] = []
+    let links: (ISbStoryData<Content> | ISbLinkURLObject | string)[] = []
 
     if (responseData.link_uuids) {
       const relSize = responseData.link_uuids.length
@@ -452,7 +453,7 @@ class Storyblok {
         })
 
         linksRes.data.stories.forEach(
-          (rel: ISbStoryData | ISbLinkURLObject | string) => {
+          (rel: ISbStoryData<Content> | ISbLinkURLObject | string) => {
             links.push(rel)
           }
         )
@@ -461,7 +462,7 @@ class Storyblok {
       links = responseData.links
     }
 
-    links.forEach((story: ISbStoryData | any) => {
+    links.forEach((story: ISbStoryData<Content> | any) => {
       this.links[resolveId][story.uuid] = {
         ...story,
         ...{ _stopResolving: true },
@@ -470,7 +471,7 @@ class Storyblok {
   }
 
   private async resolveRelations(
-    responseData: ISbResponseData,
+    responseData: ISbResponseData<Content>,
     params: ISbStoriesParams,
     resolveId: string
   ): Promise<void> {
@@ -495,7 +496,7 @@ class Storyblok {
           excluding_fields: params.excluding_fields,
         })
 
-        relationsRes.data.stories.forEach((rel: ISbStoryData) => {
+        relationsRes.data.stories.forEach((rel: ISbStoryData<Content>) => {
           relations.push(rel)
         })
       }
@@ -504,7 +505,7 @@ class Storyblok {
     }
 
     if (relations && relations.length > 0) {
-      relations.forEach((story: ISbStoryData) => {
+      relations.forEach((story: ISbStoryData<Content>) => {
         this.relations[resolveId][story.uuid] = {
           ...story,
           ...{ _stopResolving: true },
@@ -523,7 +524,7 @@ class Storyblok {
    *
    */
   private async resolveStories(
-    responseData: ISbResponseData,
+    responseData: ISbResponseData<Content>,
     params: ISbStoriesParams,
     resolveId: string
   ): Promise<void> {
@@ -563,7 +564,7 @@ class Storyblok {
     if (responseData.story) {
       this.iterateTree(responseData.story, relationParams, resolveId)
     } else {
-      responseData.stories.forEach((story: ISbStoryData) => {
+      responseData.stories.forEach((story: ISbStoryData<Content>) => {
         this.iterateTree(story, relationParams, resolveId)
       })
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   IMemoryType,
   ICacheProvider,
   ISbCustomFetch,
+  ISbResponseData,
 } from './interfaces'
 
 let memory: Partial<IMemoryType> = {}
@@ -45,15 +46,6 @@ type RelationsType = {
 
 interface ISbFlatMapped {
   data: any
-}
-
-export interface ISbResponseData {
-  link_uuids: string[]
-  links: string[]
-  rel_uuids: string[]
-  rels: any
-  story: ISbStoryData
-  stories: Array<ISbStoryData>
 }
 
 const VERSION = {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -174,7 +174,7 @@ export interface ISbLinkURLObject {
 export interface ISbStories<Content = ISbContentType> {
   data: {
     cv: number
-    links: (ISbStoryData | ISbLinkURLObject)[]
+    links: (ISbStoryData<Content> | ISbLinkURLObject)[]
     rels: ISbStoryData[]
     stories: ISbStoryData<Content>[]
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -80,9 +80,12 @@ export interface ISbComponentType<T extends string> {
   _editable?: string
 }
 
-export interface ISbStoryData<
-  Content = ISbComponentType<string> & { [index: string]: any },
-> extends ISbMultipleStoriesData {
+export interface ISbContentType extends ISbComponentType<string> {
+  [index: string]: any
+}
+
+export interface ISbStoryData<Content = ISbContentType>
+  extends ISbMultipleStoriesData {
   alternates: ISbAlternateObject[]
   breadcrumbs?: ISbLinkURLObject[]
   content: Content
@@ -168,9 +171,7 @@ export interface ISbLinkURLObject {
   uuid: string
 }
 
-export interface ISbStories<
-  Content = ISbComponentType<string> & { [index: string]: any },
-> {
+export interface ISbStories<Content = ISbContentType> {
   data: {
     cv: number
     links: (ISbStoryData | ISbLinkURLObject)[]
@@ -182,9 +183,7 @@ export interface ISbStories<
   headers: any
 }
 
-export interface ISbStory<
-  Content = ISbComponentType<string> & { [index: string]: any },
-> {
+export interface ISbStory<Content = ISbContentType> {
   data: {
     cv: number
     links: (ISbStoryData | ISbLinkURLObject)[]
@@ -269,9 +268,7 @@ export type MarkSchema = {
   (node: ISbNode): object
 }
 
-export interface ISbContentMangmntAPI<
-  Content = ISbComponentType<string> & { [index: string]: any },
-> {
+export interface ISbContentMangmntAPI<Content = ISbContentType> {
   story: {
     name: string
     slug: string
@@ -351,3 +348,12 @@ export type HtmlEscapes = {
 }
 
 export interface ISbCustomFetch extends Omit<RequestInit, 'method'> {}
+
+export interface ISbResponseData<Content = ISbContentType> {
+  link_uuids: string[]
+  links: string[]
+  rel_uuids: string[]
+  rels: any
+  story: ISbStoryData<Content>
+  stories: Array<ISbStoryData<Content>>
+}


### PR DESCRIPTION
Currently, the getter methods (eg. `getStory`, `getStories` etc) all resolve a `ISbStory`-typed object which does not contain any Space-specific type-information. So it meets the following limitations:

```ts
import StoryblokClient from "storyblok-js-client";

export const storyblokClient = new StoryblokClient({
  accessToken: "MY_TOKEN",
});

storyblokClient.getStory("xxxxxxxxxx", {}).then((response) => {
  const story = response.data.story;

  story.content.component; /* Type: string | undefined */
  response.data.story.content.name; /* "Type: any" */
});
```

The problem is that all of the properties of `response.data.story.content` are ambiguously-typed, so we'd have to type-cast it to make it useful:

```ts
type CatStory = ISbStoryData<ISbComponentType<"cat"> & { name: string }>;
type DogStory = ISbStoryData<ISbComponentType<"dog"> & { name: string }>;
// … etc

type StoryUnion = CatStory | DogStory /* | etc | etc */;

storyblokClient.getStory("xxxxxxxxxx", {}).then((response) => {
  const story = response.data.story as StoryUnion; // <- Type-casting

  story.content.component; // Type: "cat" | "dog"
  story.content.name; // Type: string
});
```

In this pull-request, I make the `Storyblok` a [Generic Class](https://www.typescriptlang.org/docs/handbook/2/generics.html#generic-classes) so that it can be instantiated with this type-information (ideally automatically generated by the Storyblok CLI's [`generate-typescript-typedefs`](https://github.com/storyblok/storyblok-cli?tab=readme-ov-file#generate-typescript-typedefs) command) to have a fully-typed API client object:

```ts
import { CatStory, DogStory {/* … etc … */} } from '@/generated/storyblok';

type StoryUnion = CatStory | DogStory /* | etc | etc */;

export const storyblokClient = new StoryblokClient<StoryUnion>({
  accessToken: "MY_TOKEN",
});

storyblokClient.getStory("xxxxxxxxxx", {}).then((response) => {
  const story = response.data.story; // Type: ISbStoryData<StoryUnion>

  story.content.component; /* Type: "cat" | "dog" */
  response.data.story.content.name; /* "Type: string" */
});
```

Note 1: The generic parameter is optional. If you omit it then the current behaviour is retained. In other words **this is a non-breaking change, and would not require a major release**.

Note 2: _Ideally_ the `StoryUnion` would be automatically generated by `generate-typescript-typedefs` - I might consider opening a separate PR for that over in that repo :)

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

See the last code-block above. Create an instance of a `Storyblok` object using the generic parameter, passing a type that represents your stories.

## What is the new behavior?

All described above.

## Other information

### Prior Art

This "typed SDK" pattern is the same one observed by many competitors' respective JS clients, for example:

- [Supabase](https://supabase.com/docs/reference/javascript/typescript-support#using-typescript-type-definitions)
- [Directus](https://docs.directus.io/guides/sdk/getting-started.html#creating-a-composable-client)
