### PR TITLE
Fix: typo in Management API interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   ISbStory,
   ISbStoryData,
   ISbStoryParams,
-  ISbContentMangmntAPI,
+  ISbContentManagementAPI,
   ISbNode,
   ThrottleFn,
   IMemoryType,
@@ -265,7 +265,7 @@ class Storyblok {
 
   public post(
     slug: string,
-    params: ISbStoriesParams | ISbContentMangmntAPI,
+    params: ISbStoriesParams | ISbContentManagementAPI,
     fetchOptions?: ISbCustomFetch
   ): Promise<ISbResponseData> {
     const url = `/${slug}`
@@ -277,7 +277,7 @@ class Storyblok {
 
   public put(
     slug: string,
-    params: ISbStoriesParams | ISbContentMangmntAPI,
+    params: ISbStoriesParams | ISbContentManagementAPI,
     fetchOptions?: ISbCustomFetch
   ): Promise<ISbResponseData> {
     const url = `/${slug}`
@@ -289,7 +289,7 @@ class Storyblok {
 
   public delete(
     slug: string,
-    params: ISbStoriesParams | ISbContentMangmntAPI,
+    params: ISbStoriesParams | ISbContentManagementAPI,
     fetchOptions?: ISbCustomFetch
   ): Promise<ISbResponseData> {
     const url = `/${slug}`

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -269,7 +269,7 @@ export type MarkSchema = {
   (node: ISbNode): object
 }
 
-export interface ISbContentMangmntAPI<
+export interface ISbContentManagementAPI<
   Content = ISbComponentType<string> & { [index: string]: any },
 > {
   story: {
@@ -287,7 +287,7 @@ export interface ISbContentMangmntAPI<
     translated_slugs_attributes?: {
       path: string
       name: string | null
-      lang: ISbContentMangmntAPI['lang']
+      lang: ISbContentManagementAPI['lang']
     }[]
   }
   force_update?: '1' | unknown
@@ -296,7 +296,7 @@ export interface ISbContentMangmntAPI<
   lang?: string
 }
 
-export interface ISbManagmentApiResult {
+export interface ISbManagementApiResult {
   data: any
   headers: any
 }


### PR DESCRIPTION
There was inconsistent/incorrect naming of the Typescript interfaces related to the ManagementAPI (`ISbContentMangmntAPI` and `ISbManagmentApiResult` respectively). In this pull-request I just rename the interfaces.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Nothing to test - simple renaming. Running `npx tsc` and seeing no type errors ensures that there were no regressions.

## What is the new behavior?

No new functional behaviour.
