### PR TITLE
Fix: Replace ambiguous `headers` types with actual types

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -179,7 +179,7 @@ export interface ISbStories<
   }
   perPage: number
   total: number
-  headers: any
+  headers: Headers
 }
 
 export interface ISbStory<
@@ -191,7 +191,7 @@ export interface ISbStory<
     rels: ISbStoryData[]
     story: ISbStoryData<Content>
   }
-  headers: any
+  headers: Headers
 }
 
 export interface IMemoryType extends ISbResult {
@@ -219,7 +219,7 @@ export interface ISbConfig {
   responseInterceptor?: ResponseFn
   fetch?: typeof fetch
   timeout?: number
-  headers?: any
+  headers?: Record<string, string>
   region?: string
   maxRetries?: number
   https?: boolean
@@ -298,7 +298,7 @@ export interface ISbContentMangmntAPI<
 
 export interface ISbManagmentApiResult {
   data: any
-  headers: any
+  headers: Headers
 }
 
 export interface ISbSchema {


### PR DESCRIPTION
Currently the `headers` types (both in the context of request/config and response) are ambiguously (`any`) typed, which prevents Typescript from being able to guard against obvious mis-configuration or mis-use of the response data.

## Pull request type

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

1. Create an instance of the Storyblok client, and try to configure both string-valued headers, and non-string-valued headers. You should expect a Typescript error when you pass a non-string value (and no error otherwise).
2. Call a getter method like `getStory` and inspect the type of `response.headers`. It should be of type [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) (with `.get` methods, et al).

```ts
const client = new Storyblok({
  headers: {
    'Content-Type': 'application/json',
    'X-Foo': [1, 2, 3], // Error: Type 'number[]' is not assignable to type 'string'
  },
})

client.getStory('xxxxxxx', {}).then((response) => {
  const contentType = response.headers.get('Content-Type') // Type: string | null
})
```

<img width="758" alt="Screenshot 2024-06-25 at 14 07 15" src="https://github.com/storyblok/storyblok-js-client/assets/12481532/cf56fb06-0234-4916-8d0e-ebb92862a75a">

<img width="676" alt="Screenshot 2024-06-25 at 14 08 20" src="https://github.com/storyblok/storyblok-js-client/assets/12481532/fd644c76-5721-4c55-9be5-672122fcb7dc">



## What is the new behavior?

No new functional behaviour - only changes to types to reflect actual runtime usage.

## Other information

None.