### PR TITLE
chore: Make "params" argument optional in getter methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,7 @@ class Storyblok {
 
   public get(
     slug: string,
-    params?: ISbStoriesParams,
+    params: ISbStoriesParams = {},
     fetchOptions?: ISbCustomFetch
   ): Promise<ISbResult> {
     if (!params) params = {} as ISbStoriesParams
@@ -237,7 +237,7 @@ class Storyblok {
 
   public async getAll(
     slug: string,
-    params: ISbStoriesParams,
+    params: ISbStoriesParams = {},
     entity?: string,
     fetchOptions?: ISbCustomFetch
   ): Promise<any[]> {
@@ -270,7 +270,7 @@ class Storyblok {
 
   public post(
     slug: string,
-    params: ISbStoriesParams | ISbContentMangmntAPI,
+    params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch
   ): Promise<ISbResponseData> {
     const url = `/${slug}`
@@ -280,7 +280,7 @@ class Storyblok {
 
   public put(
     slug: string,
-    params: ISbStoriesParams | ISbContentMangmntAPI,
+    params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch
   ): Promise<ISbResponseData> {
     const url = `/${slug}`
@@ -290,7 +290,7 @@ class Storyblok {
 
   public delete(
     slug: string,
-    params: ISbStoriesParams | ISbContentMangmntAPI,
+    params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch
   ): Promise<ISbResponseData> {
     const url = `/${slug}`
@@ -299,7 +299,7 @@ class Storyblok {
   }
 
   public getStories(
-    params: ISbStoriesParams,
+    params: ISbStoriesParams = {},
     fetchOptions?: ISbCustomFetch
   ): Promise<ISbStories> {
     this._addResolveLevel(params)
@@ -309,7 +309,7 @@ class Storyblok {
 
   public getStory(
     slug: string,
-    params: ISbStoryParams,
+    params: ISbStoryParams = {},
     fetchOptions?: ISbCustomFetch
   ): Promise<ISbStory> {
     this._addResolveLevel(params)

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,6 @@ class Storyblok {
     params: ISbStoriesParams = {},
     fetchOptions?: ISbCustomFetch
   ): Promise<ISbResult> {
-    if (!params) params = {} as ISbStoriesParams
     const url = `/${slug}`
     const query = this.factoryParamOptions(url, params)
 


### PR DESCRIPTION
Small (backward-compatible) change to the `.getStory` (et al) methods to make the second argument (params) optional. So that you can simplify your code in the following way:

```diff
import StoryblokClient from "storyblok-js-client";

const storyblokClient = new StoryblokClient({
  // …
});

-storyblokClient.getStory(slug, {}) // Passing redundant empty-object 
+storyblokClient.getStory(slug)
  .then(console.log)
  .catch(console.error);
```

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- Make a call to `client.getAll`, `client.get`, `client.getStories` or `client.getStory`.
- Don't pass the `params` argument.
- Expect no Typescript error.
- Expect no runtime error.

## What is the new behavior?

There is no Typescript or runtime error when you defer to the client defaults (omit the `params` argument) when calling the Storyblok client's getter methods.