### PR TITLE
feat: pro 425 deprecation warnings legacy richtext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ gitcommit.fish
 .env.test
 .env
 .next
+
+old-tests/

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -1,4 +1,6 @@
-import StoryblokClient, { RichtextSchema } from '../'
+import StoryblokClient, { RichtextResolver, RichtextSchema } from '../'
 
 const client = new StoryblokClient({})
-console.log(client, RichtextSchema)
+
+// TODO: Remove when deprecation of `RichtextResolver` is done
+console.log(new RichtextResolver().render())

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ class Storyblok {
   private resolveCounter: number
   public relations: RelationsType
   public links: LinksType
+  // TODO: Remove on v7.x.x
   public richTextResolver: RichTextResolver
   public resolveNestedRelations: boolean
   private stringifiedStoriesCache: Record<string, string>

--- a/src/richTextResolver.ts
+++ b/src/richTextResolver.ts
@@ -83,6 +83,9 @@ class RichTextResolver {
     data?: ISbRichtext,
     options: RenderOptions = { optimizeImages: false }
   ) {
+    console.warn(
+      "Warning ⚠️: The RichTextResolver class is deprecated and will be removed in the next major release. Please use the `@storyblok/richtext` instead. https://github.com/storyblok/richtext/"
+    );
     if (data && data.content && Array.isArray(data.content)) {
       let html = ''
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other (please describe):

Warning campaign

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

Run the playground

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- When user imports the legacy `RichtextResolver` and uses `render` function, a warning should show on the console
![Screenshot 2024-07-31 at 10 11 23](https://github.com/user-attachments/assets/0b1407d8-848c-47ab-9ded-13988f6dbf8a)

## Other information
