### PR TITLE
Fix: check for ownProperties on Richtext renderer HTML attributes

### DIFF
--- a/src/richTextResolver.ts
+++ b/src/richTextResolver.ts
@@ -330,9 +330,11 @@ class RichTextResolver {
         let h = `<${tag.tag}`
         if (tag.attrs) {
           for (const key in tag.attrs) {
-            const value = tag.attrs[key]
-            if (value !== null) {
-              h += ` ${key}="${value}"`
+            if (Object.prototype.hasOwnProperty.call(tag.attrs, key)) {
+              const value = tag.attrs[key]
+              if (value !== null) {
+                h += ` ${key}="${value}"`
+              }
             }
           }
         }


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- Add a property to `tag.attrs` prototype
- Render a Richtext field
- Check that the added property is NOT looped over

## What is the new behavior?

This PR fixes a potential security issue related to looping over object properties without assessing if they are object own properties or part of the prototype chain.