### PR TITLE
fix: support object based headers

### DIFF
--- a/playground/vanilla/src/main.ts
+++ b/playground/vanilla/src/main.ts
@@ -4,7 +4,10 @@ import './style.css'
 
 const headers = new Headers()
 headers.append('Awiwi', 'Awiwi')
-
+const headers2 = {
+  'Awiwi': 'Awiwi'
+}
+console.log(headers2.constructor.name)
 // 2. Initialize the client with the preview token
 // from your space dashboard at https://app.storyblok.com
 const Storyblok = new StoryblokClient({

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ class Storyblok {
     headers.set('Accept', 'application/json')
 
     if (config.headers) {
-      const entries = config.headers.entries().toArray()
+      const entries = (config.headers.constructor.name === 'Headers') ? config.headers.entries().toArray() : Object.entries(config.headers)
 
       entries.forEach(([key, value]: [string, string]) => {
         headers.set(key, value)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Fixes https://github.com/storyblok/storyblok-cli/issues/107

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- Run the vanilla playground

## What is the new behavior?

`headers` property now supports both object based headers or `new Headers` 

```ts
const headers = new Headers()
headers.append('Awiwi', 'Awiwi')
const headers2 = {
  'Awiwi': 'Awiwi'
}
// Both should work
// 2. Initialize the client with the preview token
// from your space dashboard at https://app.storyblok.com
const Storyblok = new StoryblokClient({
  accessToken: import.meta.env.VITE_ACCESS_TOKEN as string,
  headers,
})
```

## Other information
