### PR TITLE
feat: add generic types to get story functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,11 +224,11 @@ class Storyblok {
     return this.cacheResponse(url, query, undefined, fetchOptions)
   }
 
-  public get(
+  public get<T = any>(
     slug: string,
     params?: ISbStoriesParams,
     fetchOptions?: ISbCustomFetch
-  ): Promise<ISbResult> {
+  ): Promise<ISbResult<T>> {
     if (!params) params = {} as ISbStoriesParams
     const url = `/${slug}`
     const query = this.factoryParamOptions(url, params)
@@ -236,12 +236,12 @@ class Storyblok {
     return this.cacheResponse(url, query, undefined, fetchOptions)
   }
 
-  public async getAll(
+  public async getAll<T = any>(
     slug: string,
     params: ISbStoriesParams,
     entity?: string,
     fetchOptions?: ISbCustomFetch
-  ): Promise<any[]> {
+  ): Promise<T[]> {
     const perPage = params?.per_page || 25
     const url = `/${slug}`
     const urlParts = url.split('/')
@@ -299,20 +299,20 @@ class Storyblok {
     return Promise.resolve(this.throttle('delete', url, params, fetchOptions))
   }
 
-  public getStories(
+  public getStories<T = any>(
     params: ISbStoriesParams,
     fetchOptions?: ISbCustomFetch
-  ): Promise<ISbStories> {
+  ): Promise<ISbStories<T>> {
     this._addResolveLevel(params)
 
     return this.get('cdn/stories', params, fetchOptions)
   }
 
-  public getStory(
+  public getStory<T = any>(
     slug: string,
     params: ISbStoryParams,
     fetchOptions?: ISbCustomFetch
-  ): Promise<ISbStory> {
+  ): Promise<ISbStory<T>> {
     this._addResolveLevel(params)
 
     return this.get(`cdn/stories/${slug}`, params, fetchOptions)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -230,8 +230,8 @@ export interface ISbConfig {
   endpoint?: string
 }
 
-export interface ISbResult {
-  data: any
+export interface ISbResult<T = any> {
+  data: T
   perPage: number
   total: number
   headers: Headers


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: No Jira Link available.

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

This PR introduces type changes to `.get`, `.getAll`, `.getStory` and `.getStories`. The new behaviour can be tested by using those functions with generic types like this:

```ts
import StoryblokClient from 'storyblok-js-client'

interface MyCustomType {
  foo: bar;
}

let client = new StoryblokClient({
  accessToken: '<YOUR_SPACE_ACCESS_TOKEN>',
})

const res = client.getStory<MyCustomType>('home')
```

If you hover over `res` in your IDE it should be of type `ISbStory<MyCustomType>`

## What is the new behavior?

This PR adds optional generic types to these functions to allow for easier typing when using this client.
With `ISbStory` and `ISbStories` there already are generic interfaces for typing stories, those had to be manually assigned for now though. `ISbResult` got generic in this PR.