### PR TITLE
fix: remove trailing slash from slug passed to getAll()

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -289,6 +289,25 @@ describe('StoryblokClient', () => {
       await client.getAll('links', { per_page: 1 })
       expect(mockMakeRequest).toBeCalledTimes(2)
     })
+
+    it('should get all stories if the slug is passed with the trailing slash', async () => {
+      const mockMakeRequest = vi.fn().mockResolvedValue({
+        data: {
+          stories: [
+            { id: 1, name: 'Test Story 1' },
+            { id: 2, name: 'Test Story 2' },
+          ],
+        },
+        total: 2,
+        status: 200,
+      })
+      client.makeRequest = mockMakeRequest
+      const result = await client.getAll('cdn/stories/', { version: 'draft' })
+      expect(result).toEqual([
+        { id: 1, name: 'Test Story 1' },
+        { id: 2, name: 'Test Story 2' },
+      ])
+    })
   })
 
   describe('post', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,9 +243,8 @@ class Storyblok {
     fetchOptions?: ISbCustomFetch
   ): Promise<any[]> {
     const perPage = params?.per_page || 25
-    const url = `/${slug}`
-    const urlParts = url.split('/')
-    const e = entity || urlParts[urlParts.length - 1]
+    const url = `/${slug}`.replace(/\/$/, '')
+    const e = entity ?? url.substring(url.lastIndexOf('/') + 1)
 
     const firstPage = 1
     const firstRes = await this.makeRequest(


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Closes #822 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Call `getAll()` with a slug with a trailing slash. Before this PR, this results in a TypeError.

## What is the new behavior?

No TypeError in the above mentioned case.

