### PR TITLE
fix: properly reject throttle queue errors

### DIFF
--- a/src/throttlePromise.ts
+++ b/src/throttlePromise.ts
@@ -30,8 +30,13 @@ function throttledQueue<T extends (...args: Parameters<T>) => ReturnType<T>>(
 
     const x = queue.shift();
     if (x) {
-      const res = await fn(...x.args);
-      x.resolve(res);
+      try {
+        const res = await fn(...x.args);
+        x.resolve(res);
+      }
+      catch (error) {
+        x.reject(error);
+      }
     }
 
     const id = setTimeout(() => {


### PR DESCRIPTION
Hopefully solves some of the CLI issues with correct error handling on the throttle
