### PR TITLE
fix: params in delete method should be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Storyblok.post(`spaces/${spaceId}/stories`, {
 Storyblok.put(`spaces/${spaceId}/stories/1`, {
   story: { name: "xy", slug: "xy" },
 });
-Storyblok.delete(`spaces/${spaceId}/stories/1`, null);
+Storyblok.delete(`spaces/${spaceId}/stories/1`);
 ```
 
 ### Using the RichTextResolver separately
@@ -402,7 +402,7 @@ Storyblok.put('spaces/<YOUR_SPACE_ID>/stories/1', {
 **Example**
 
 ```javascript
-Storyblok.delete('spaces/<YOUR_SPACE_ID>/stories/1', null)
+Storyblok.delete('spaces/<YOUR_SPACE_ID>/stories/1')
   .then((response) => {
     console.log(response)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,6 +300,9 @@ class Storyblok {
     params: ISbStoriesParams | ISbContentMangmntAPI,
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbResponseData> {
+    if (!params) {
+      params = {} as ISbStoriesParams;
+    }
     const url = `/${slug}`;
 
     return Promise.resolve(

--- a/src/sbFetch.test.ts
+++ b/src/sbFetch.test.ts
@@ -109,7 +109,7 @@ describe('sbFetch', () => {
         status: 204, // Typically, DELETE operations might not return content
       });
       mockFetch.mockResolvedValue(response);
-      await sbFetch.delete('stories/1', {});
+      await sbFetch.delete('stories/1');
       expect(mockFetch).toHaveBeenCalledWith(
         'https://api.storyblok.com/v2/stories/1',
         {

--- a/src/sbFetch.ts
+++ b/src/sbFetch.ts
@@ -68,9 +68,9 @@ class SbFetch {
     return this._methodHandler('put');
   }
 
-  public delete(url: string, params: ISbStoriesParams) {
+  public delete(url: string, params?: ISbStoriesParams) {
     this.url = url;
-    this.parameters = params;
+    this.parameters = params ?? {} as ISbStoriesParams;
     return this._methodHandler('delete');
   }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

FIxes #884 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Other (please describe): documentation and code differs

## How to test this PR

Call a delete operation without providing the second argument

## What is the new behavior?

The `StoryblokClient.delete()` method can be called without passing the second `params` argument.

## Other information
