### PR TITLE
chore: mark changelog.md as deprecated

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
-# Change Log
+# Change Log (deprecated)
 
-All notable changes to this project will be documented in this file.
+This file is **no longer maintained**. To learn about changes made in specific versions of this library, check out its [GitHub releases](https://github.com/storyblok/storyblok-js-client/releases).
 
 ## [6.6.4] - 2024-01-26
 


### PR DESCRIPTION
When a user of this library wants to learn what changed between releases, they might look at the `changelog.md` file. This gives them the wrong impression that the library is no longer describing it changes between releases because the changelog ends at a version from a year ago.

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other (please describe): documentation
