### PR TITLE
refactor(type): add type aware getAll function that works with ISbLinksParams

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import type {
   ISbConfig,
   ISbContentMangmntAPI,
   ISbCustomFetch,
+  ISbLink,
   ISbLinksParams,
   ISbLinksResult,
   ISbLinkURLObject,
@@ -215,7 +216,7 @@ class Storyblok {
 
   private makeRequest(
     url: string,
-    params: ISbStoriesParams,
+    params: ISbStoriesParams | ISbLinksParams,
     per_page: number,
     page: number,
     fetchOptions?: ISbCustomFetch,
@@ -254,12 +255,12 @@ class Storyblok {
     return this.cacheResponse(url, query, undefined, fetchOptions);
   }
 
-  public async getAll(
-    slug: string,
-    params: ISbStoriesParams,
+  public async getAll<T extends string>(
+    slug: T,
+    params: T extends 'cdn/links' ? ISbLinksParams : ISbStoriesParams,
     entity?: string,
     fetchOptions?: ISbCustomFetch,
-  ): Promise<any[]> {
+  ): Promise<T extends 'cdn/links' ? ISbLink[] : any[]> {
     const perPage = params?.per_page || 25;
     const url = `/${slug}`.replace(/\/$/, '');
     const e = entity ?? url.substring(url.lastIndexOf('/') + 1);

--- a/src/sbHelpers.ts
+++ b/src/sbHelpers.ts
@@ -1,6 +1,7 @@
 import type {
   AsyncFn,
   HtmlEscapes,
+  ISbLinksParams,
   ISbResult,
   ISbStoriesParams,
 } from './interfaces';
@@ -19,7 +20,7 @@ export class SbHelpers {
   public isCDNUrl = (url = '') => url.includes('/cdn/');
 
   public getOptionsPage = (
-    options: ISbStoriesParams,
+    options: ISbStoriesParams | ISbLinksParams,
     perPage = 25,
     page = 1,
   ) => {

--- a/tests/api/index.e2e.ts
+++ b/tests/api/index.e2e.ts
@@ -1,3 +1,4 @@
+import type { ISbLink } from 'storyblok-js-client';
 import StoryblokClient from 'storyblok-js-client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -85,20 +86,27 @@ describe('StoryblokClient', () => {
   });
 
   describe('getAll function', () => {
+    it('getAll(\'cdn/links\') should return all links', async () => {
+      const result: ISbLink[] = await client.getAll('cdn/links', {
+        include_dates: 1,
+      });
+      expect(result.length).toBeGreaterThan(0);
+    });
+
     it('getAll(\'cdn/stories\') should return all stories', async () => {
-      const result = await client.getAll('cdn/stories', {});
+      const result: any[] = await client.getAll('cdn/stories', {});
       expect(result.length).toBeGreaterThan(0);
     });
 
     it('getAll(\'cdn/stories\') should return all stories with filtered results', async () => {
-      const result = await client.getAll('cdn/stories', {
+      const result: any[] = await client.getAll('cdn/stories', {
         starts_with: 'testcontent-0',
       });
       expect(result.length).toBe(1);
     });
 
     it('getAll(\'cdn/stories\', filter_query: { __or: [{ category: { any_in_array: \'Category 1\' } }, { category: { any_in_array: \'Category 2\' } }]}) should return all stories with the specific filter applied', async () => {
-      const result = await client.getAll('cdn/stories', {
+      const result: any[] = await client.getAll('cdn/stories', {
         filter_query: {
           __or: [
             { category: { any_in_array: 'Category 1' } },
@@ -110,14 +118,14 @@ describe('StoryblokClient', () => {
     });
 
     it('getAll(\'cdn/stories\', {by_slugs: \'folder/*\'}) should return all stories with the specific filter applied', async () => {
-      const result = await client.getAll('cdn/stories', {
+      const result: any[] = await client.getAll('cdn/stories', {
         by_slugs: 'folder/*',
       });
       expect(result.length).toBeGreaterThan(0);
     });
 
     it('getAll(\'cdn/links\') should return all links', async () => {
-      const result = await client.getAll('cdn/links', {});
+      const result: ISbLink[] = await client.getAll('cdn/links', {});
       expect(result.length).toBeGreaterThan(0);
     });
   });


### PR DESCRIPTION
Problem:
- Developers may need to `getAll` when getting an unpaginated response from `cdn/links`
- Currently when calling `cdn/links` with ISbLinksParams results with compile time error when using ISbLinksParams specific params like: include_dates

Solution:
- Make `getAll` function generic to make it type aware of the intention of the developer
- Updated unit tests and e2e tests

Closes: https://github.com/storyblok/storyblok-js-client/issues/944

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
```
await storyBlokClient.getAll('cdn/links', {
      starts_with: 'some-path',
      version: 'published',
      include_dates: 1 // this should not throw TS error
    });
```

## Breaking change

Updated the `getAll` function to not allow developers to modify the number of round trips for fetching all results. i.e, this will not compile:

```
await storyBlokClient.getAll('cdn/links', {
      starts_with: 'some-path',
      version: 'published',
      page: 1 // this should throw TS error
    });
```