### PR TITLE
add sort_by_date definition to ISbContentMangmntAPI type def

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -309,6 +309,7 @@ export interface ISbContentMangmntAPI<
     is_startpage?: boolean;
     position?: number;
     first_published_at?: string;
+    sort_by_date?: string;
     translated_slugs_attributes?: {
       path: string;
       name: string | null;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
ISbContentMangmntAPI posts via `storyblok.post() accepts `sort_by_date` in the payload but it isn't included in the type definition

## Pull request type

Jira Link: INT-random-guy-on-the-internet

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

## What is the new behaviour?

- Added a single line to interfaces type file.


## Other information

