### PR TITLE
fix(statusHandler): error response matching with type ISbResponse

### DIFF
--- a/src/sbFetch.ts
+++ b/src/sbFetch.ts
@@ -182,9 +182,7 @@ class SbFetch {
       const error: ISbError = {
         message: res.statusText,
         status: res.status,
-        response: Array.isArray(res.data)
-          ? res.data[0]
-          : res.data.error || res.data.slug,
+        response: res,
       };
 
       reject(error);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Solving issue *https://github.com/storyblok/storyblok-js-client/issues*

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- Run a project without `access token`
- The error message should have the expected type:
```
  export interface ISbResponse {
    data: any;
    status: number;
    statusText: string;
    headers: any;
  }
  
  export interface ISbError {
    message?: string;
    status?: number;
    response?: ISbResponse;
  }
```
The error response should be typed like an *ISbResponse*, and currently for this case it is a string

## What is the new behavior?

Error response from:
`{ message: "", status: 401, response: "Unauthorized" }`

To:
```
{
    "message": "",
    "status": 401,
    "response": {
        "data": {
            "error": "Unauthorized"
        },
        "headers": {
            "cache-control": "no-cache",
            "content-length": "24",
            "content-type": "application/json; charset=utf-8"
        },
        "status": 401,
        "statusText": ""
    }
}
```

## Other information

- On `_statusHandler`, the parameter is typed as ISbResponse, and this is the type expected from ISbError["response"], so I am just passing it along
