### PR TITLE
fix: having null or undefined values breaks stringify

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1157,4 +1157,88 @@ describe('storyblokClient', () => {
       expect(storyData.localized_paths).toBeDefined();
     });
   });
+
+  describe('getStory', () => {
+    it('should handle undefined resolve_relations parameter gracefully', async () => {
+      const storySlug = 'test-story';
+      const mockStoryResponse = {
+        data: {
+          story: {
+            id: 123,
+            uuid: 'test-uuid',
+            name: 'Test Story',
+            content: {
+              _uid: 'test-uid',
+              component: 'test',
+              title: 'Test Title',
+            },
+          },
+        },
+        headers: {},
+        status: 200,
+      };
+
+      // Mock the get method which getStory calls internally
+      client.get = vi.fn().mockResolvedValue(mockStoryResponse);
+
+      // Call getStory without resolve_relations
+      const result = await client.getStory(storySlug, {
+        version: 'published',
+        // No resolve_relations parameter
+      });
+
+      // Verify the function executed without errors
+      expect(result).toEqual(mockStoryResponse);
+
+      // Verify that get was called with the right parameters
+      expect(client.get).toHaveBeenCalledWith(
+        `cdn/stories/${storySlug}`,
+        {
+          version: 'published',
+          // resolve_level should not be added since resolve_relations was undefined
+        },
+        undefined,
+      );
+    });
+
+    it('should add resolve_level when resolve_relations is provided', async () => {
+      const storySlug = 'test-story';
+      const mockStoryResponse = {
+        data: {
+          story: {
+            id: 123,
+            uuid: 'test-uuid',
+            name: 'Test Story',
+            content: {
+              _uid: 'test-uid',
+              component: 'test',
+              title: 'Test Title',
+            },
+          },
+        },
+        headers: {},
+        status: 200,
+      };
+
+      // Mock the get method
+      client.get = vi.fn().mockResolvedValue(mockStoryResponse);
+
+      // Call getStory with resolve_relations
+      await client.getStory(storySlug, {
+        version: 'published',
+        resolve_relations: 'test.relation',
+      });
+
+      // Verify that get was called with resolve_level added
+      expect(client.get).toHaveBeenCalledWith(
+        `cdn/stories/${storySlug}`,
+        {
+          version: 'published',
+          resolve_relations: 'test.relation',
+          resolve_level: 2,
+        },
+        undefined,
+      );
+    });
+  });
 });

--- a/src/sbHelpers.test.ts
+++ b/src/sbHelpers.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SbHelpers } from './sbHelpers';
+import type { ISbResult } from './interfaces';
+
+type RangeFn = (...args: any) => [];
 
 describe('sbHelpers', () => {
   let helpers: SbHelpers;
@@ -63,8 +66,8 @@ describe('sbHelpers', () => {
   describe('asyncMap', () => {
     it('applies an async function to each element in the array', async () => {
       const numbers = [1, 2, 3];
-      const doubleAsync = async (n: number) => n * 2;
-      const results = await helpers.asyncMap(numbers, doubleAsync);
+      const doubleAsync = async (n: number) => (n * 2) as unknown as Promise<ISbResult>;
+      const results = await helpers.asyncMap(numbers as unknown as RangeFn[], doubleAsync);
       expect(results).toEqual([2, 4, 6]);
     });
   });
@@ -76,7 +79,7 @@ describe('sbHelpers', () => {
         { id: 2, values: [30, 40] },
       ];
       const flattenValues = (item: { values: number[] }) => item.values;
-      const result = helpers.flatMap(data, flattenValues);
+      const result = helpers.flatMap(data as unknown as ISbResult[], flattenValues);
       expect(result).toEqual([10, 20, 30, 40]);
     });
   });
@@ -92,6 +95,41 @@ describe('sbHelpers', () => {
       const params = { names: ['John', 'Jane'] };
       const result = helpers.stringify(params, '', true);
       expect(result).toBe('=John&=Jane');
+    });
+
+    it('handles undefined values', () => {
+      const params = { name: 'John', age: undefined };
+      const result = helpers.stringify(params);
+      expect(result).toBe('name=John');
+    });
+
+    it('handles null values', () => {
+      const params = { name: 'John', age: null };
+      const result = helpers.stringify(params);
+      expect(result).toBe('name=John');
+    });
+
+    it('handles null and undefined values', () => {
+      const params = { name: 'John', age: null, city: undefined, country: 'Italy' };
+      const result = helpers.stringify(params);
+      expect(result).toBe('name=John&country=Italy');
+    });
+
+    it('handles empty string values', () => {
+      const params = { name: 'John', age: null, city: undefined, country: '' };
+      const result = helpers.stringify(params);
+      expect(result).toBe('name=John&country=');
+    });
+
+    it('does not break when given an empty object', () => {
+      const params = {};
+      const result = helpers.stringify(params);
+      expect(result).toBe('');
+    });
+
+    it('does not break when given a null params', () => {
+      const result = helpers.stringify(null as any);
+      expect(result).toBe('');
     });
   });
 

--- a/src/sbHelpers.ts
+++ b/src/sbHelpers.ts
@@ -64,6 +64,9 @@ export class SbHelpers {
         continue;
       }
       const value = params[key];
+      if (value === null || value === undefined) {
+        continue;
+      }
       const enkey = isArray ? '' : encodeURIComponent(key);
       let pair;
       if (typeof value === 'object') {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Fixes: #960 

A recent commit added the `starts_with` param to the recursive `resolve_relations` method, and when the param is undefined it produces a `starts_with=undefined` URL which breaks the API.

This commit fixes the bug by stripping null or undefined values from the final URL.

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Unit tests included.

