### PR TITLE
feat: make params argument optional in getter methods

### DIFF
--- a/playground/vanilla/src/main.ts
+++ b/playground/vanilla/src/main.ts
@@ -6,11 +6,11 @@ const capi = new StoryblokClient({
   version: 'draft',
 })
 
-
 const mapi = new StoryblokClient({
   oauthToken: import.meta.env.VITE_OAUTH_TOKEN as string,
   region: 'eu',
 })
+
 
 // Function to check if tokens are available
 const checkTokens = () => {
@@ -59,10 +59,11 @@ const handleError = (error: any) => {
  * @returns Promise with the story data
  */
 const getStories = async () => {
-  return await capi.get('cdn/stories/', {
+  /* return await capi.get('cdn/stories/', {
     version: 'draft',
     resolve_relations: 'root.author',
-  })
+  }) */
+  return await capi.getStories()
 }
 
 /**
@@ -70,9 +71,7 @@ const getStories = async () => {
  * @returns Promise with the links data
  */
 const getLinks = async () => {
-  return await capi.getAll('cdn/links', {
-    version: 'published',
-  })
+  return await capi.getAll('cdn/links')
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,7 @@ class Storyblok {
 
   public get(
     slug: string,
-    params?: ISbStoriesParams | ISbLinksParams,
+    params: ISbStoriesParams | ISbLinksParams = {},
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbResult | ISbLinksResult> {
     if (!params) {
@@ -236,13 +236,10 @@ class Storyblok {
 
   public async getAll(
     slug: string,
-    params: ISbStoriesParams,
+    params: ISbStoriesParams = {},
     entity?: string,
     fetchOptions?: ISbCustomFetch,
   ): Promise<any[]> {
-    if (!params) {
-      params = {} as ISbStoriesParams;
-    }
     const perPage = params?.per_page || 25;
     const url = `/${slug}`.replace(/\/$/, '');
     const e = entity ?? url.substring(url.lastIndexOf('/') + 1);
@@ -271,7 +268,7 @@ class Storyblok {
 
   public post(
     slug: string,
-    params: ISbStoriesParams | ISbContentMangmntAPI,
+    params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbResponseData> {
     const url = `/${slug}`;
@@ -281,7 +278,7 @@ class Storyblok {
 
   public put(
     slug: string,
-    params: ISbStoriesParams | ISbContentMangmntAPI,
+    params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbResponseData> {
     const url = `/${slug}`;
@@ -291,7 +288,7 @@ class Storyblok {
 
   public delete(
     slug: string,
-    params: ISbStoriesParams | ISbContentMangmntAPI,
+    params: ISbStoriesParams | ISbContentMangmntAPI = {},
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbResponseData> {
     if (!params) {
@@ -303,7 +300,7 @@ class Storyblok {
   }
 
   public getStories(
-    params: ISbStoriesParams,
+    params: ISbStoriesParams = {},
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbStories> {
     this._addResolveLevel(params);
@@ -313,7 +310,7 @@ class Storyblok {
 
   public getStory(
     slug: string,
-    params: ISbStoryParams,
+    params: ISbStoryParams = {},
     fetchOptions?: ISbCustomFetch,
   ): Promise<ISbStory> {
     this._addResolveLevel(params);


### PR DESCRIPTION
This PR makes the second argument (params) for requests optional. Originally done on  #836 