### PR TITLE
fix: `resolve_assets` parameter missing from story params interface

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -50,6 +50,7 @@ export interface ISbStoryParams {
   token?: string;
   find_by?: 'uuid';
   version?: StoryblokContentVersionKeys;
+  resolve_assets?: number;
   resolve_links?: 'link' | 'url' | 'story' | '0' | '1';
   resolve_links_level?: 1 | 2;
   resolve_relations?: string | string[];


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Use the `resovle_assets` parameter in the `getStory` method.

## What is the new behavior?

- TypeScript should no longer generate the following error: `Object literal may only specify known properties, and 'resolve_assets' does not exist in type 'ISbStoryParams'.`

## Other information
Fix based on parameters shown in the [documentation](https://www.storyblok.com/docs/api/content-delivery/v2/stories/retrieve-a-single-story)